### PR TITLE
Adds option to save current settings to local storage.

### DIFF
--- a/PSW/PSW/Views/Home/Components/Packages/Default.cshtml
+++ b/PSW/PSW/Views/Home/Components/Packages/Default.cshtml
@@ -224,6 +224,7 @@
                         </div>
                         <div class="form-group text-right">
                             <a href="/" class="btn btn-warning" id="reset"><i class="ion-ios-arrow-left"></i> Reset to Defaults</a>
+                            <button class="btn btn-primary ml-2" id="save" name="save" title="Saves current settings to your local browser storage"><i class="ion-save"></i> Save</button>
                             <button class="btn btn-success ml-2" id="update" name="update"><i class="ion-checkmark-circled"></i> Update Script</button>
                         </div>
                     </div>

--- a/PSW/PSW/wwwroot/js/site.js
+++ b/PSW/PSW/wwwroot/js/site.js
@@ -26,12 +26,19 @@
         reset: document.getElementById('reset'),
         copy: document.getElementById('copy'),
         generate: document.getElementById('generate'),
-        update: document.getElementById('update')
+        update: document.getElementById('update'),
+        save: document.getElementById('save')
     },
     init: function () {
         psw.addListeners();
+        psw.setFromLocalStorage();
     },
     addListeners() {
+        psw.buttons.save.addEventListener('click', function (event) {
+            event.preventDefault();
+            window.localStorage.setItem("searchParams", window.location.search);
+        });
+
         psw.buttons.clearpackages.addEventListener('click', function (event) {
             psw.clearAllPackages(event);
             psw.updateOutput();
@@ -325,6 +332,38 @@
         psw.controls.userFriendlyName.removeAttribute('disabled');
         psw.controls.userEmail.removeAttribute('disabled');
         psw.controls.userPassword.removeAttribute('disabled');
+    },
+    setFromLocalStorage: function () {
+        if (window.localStorage.getItem("searchParams") == null) {
+            return reset();
+        }
+
+        var searchParams = new URLSearchParams(window.localStorage.getItem("searchParams"));
+
+        psw.controls.installUmbracoTemplate.checked = searchParams.get("InstallUmbracoTemplate") === "true";
+        psw.controls.umbracoTemplateVersion.value = searchParams.get("UmbracoTemplateVersion");
+        psw.controls.includeStarterKit.checked = searchParams.get("IncludeStarterKit") === "true";
+        psw.controls.starterKitPackage.value = searchParams.get("StarterKitPackage");
+        psw.controls.createSolutionFile.checked = searchParams.get("CreateSolutionFile") === "true";
+        psw.controls.solutionName.value = searchParams.get("SolutioName");
+        psw.controls.projectName.value = searchParams.get("ProjectName");
+        psw.controls.useUnattendedInstall.checked = searchParams.get("UseUnattendedInstall") === "true";
+        psw.controls.connectionString.value = searchParams.get("ConnectionString");
+        psw.controls.userFriendlyName.value = searchParams.get("UserFriendlyName");
+        psw.controls.userEmail.value = searchParams.get("UserEmail");
+        psw.controls.userPassword.value = searchParams.get("UserPassword");
+        psw.controls.databaseType.value = searchParams.get("DatabaseType");
+
+        psw.controls.umbracoTemplateVersion.disabled = !psw.controls.installUmbracoTemplate.checked;
+        psw.controls.starterKitPackage.disabled = !psw.controls.includeStarterKit.checked;
+        psw.controls.solutionName.disabled = !psw.controls.createSolutionFile.checked;
+        psw.controls.databaseType.disabled = !psw.controls.useUnattendedInstall.checked;
+        psw.controls.userFriendlyName.disabled = !psw.controls.useUnattendedInstall.checked;
+        psw.controls.userEmail.disabled = !psw.controls.useUnattendedInstall.checked;
+        psw.controls.userPassword.disabled = !psw.controls.useUnattendedInstall.checked;
+
+        psw.updateOutput();
+        psw.updateUrl();
     },
     filterPackages: function () {
         var filter, ul, li, a, i, txtValue;


### PR DESCRIPTION
One thing I miss, is the ability to have the site remember what I want to use as eg. username and password for unattended installs. I know it generates a URL with querystring parameters for this, but then I'm required to either remember the url or add a bookmark (that I then need to find) in order to use those.

So I added functionality to save the current settings to the browsers localstorage (it simply saves the querystring), and on initialization it will read the settings from localstorage and apply them.

![image](https://user-images.githubusercontent.com/3726467/197389745-a29cb3bb-9f43-428f-a5d4-1b74e8537386.png)
