### PR TITLE
Update "-i" to "install" as depreciated

### DIFF
--- a/PSW/PSW/Services/ScriptGeneratorService.cs
+++ b/PSW/PSW/Services/ScriptGeneratorService.cs
@@ -49,11 +49,11 @@ public class ScriptGeneratorService : IScriptGeneratorService
         
         if (!string.IsNullOrWhiteSpace(model.UmbracoTemplateVersion))
         {
-            outputList.Add($"dotnet new -i Umbraco.Templates::{model.UmbracoTemplateVersion}");
+            outputList.Add($"dotnet new install Umbraco.Templates::{model.UmbracoTemplateVersion}");
         }
         else
         {
-            outputList.Add("dotnet new -i Umbraco.Templates");
+            outputList.Add("dotnet new install Umbraco.Templates");
         }
         
         outputList.Add("");


### PR DESCRIPTION
Running command as is gives following:
```
$ dotnet new -i Umbraco.Templates

Warning: use of 'dotnet new --install' is deprecated. Use 'dotnet new install' instead. For more information, run:

   dotnet new install -h
```

Have updated to resolve