### PR TITLE
Updates to the Umbraco.Templates command

### DIFF
--- a/PSW/PSW/Models/GeneratorApiRequest.cs
+++ b/PSW/PSW/Models/GeneratorApiRequest.cs
@@ -15,6 +15,7 @@ public class GeneratorApiRequest
     }
     public bool InstallUmbracoTemplate { get; set; }
     public string? UmbracoTemplateVersion { get; set; }
+    public bool ForceTemplateInstall { get; set; }
     public string? Packages { get; set; }
     public bool CreateSolutionFile { get; set; }
     public string? SolutionName { get; set; }

--- a/PSW/PSW/Models/PackagesViewModel.cs
+++ b/PSW/PSW/Models/PackagesViewModel.cs
@@ -10,6 +10,7 @@ public class PackagesViewModel
     {
         InstallUmbracoTemplate = apiRequest.InstallUmbracoTemplate;
         UmbracoTemplateVersion = apiRequest.UmbracoTemplateVersion;
+        ForceTemplateInstall = apiRequest.ForceTemplateInstall;
         CreateSolutionFile = apiRequest.CreateSolutionFile;
         SolutionName = apiRequest.SolutionName;
         ProjectName = apiRequest.ProjectName;
@@ -31,6 +32,9 @@ public class PackagesViewModel
 
     [Display(Name = "Umbraco Template Version:")]
     public string? UmbracoTemplateVersion { get; set; }
+
+    [Display(Name = "--force")]
+    public bool ForceTemplateInstall { get; set; }
 
     public List<PagedPackagesPackage>? AllPackages { get; set; }
     public string? Packages { get; set; }

--- a/PSW/PSW/Services/QueryStringService.cs
+++ b/PSW/PSW/Services/QueryStringService.cs
@@ -8,6 +8,7 @@ public class QueryStringService : IQueryStringService
     {
         _ = bool.TryParse(request.Query[nameof(PackagesViewModel.IncludeStarterKit)], out var includeStarterKit);
         _ = bool.TryParse(request.Query[nameof(PackagesViewModel.InstallUmbracoTemplate)], out var installUmbracoTemplate);
+        _ = bool.TryParse(request.Query[nameof(PackagesViewModel.ForceTemplateInstall)], out var forceTemplateInstall);
         _ = bool.TryParse(request.Query[nameof(PackagesViewModel.CreateSolutionFile)], out var createSolutionFile);
         _ = bool.TryParse(request.Query[nameof(PackagesViewModel.UseUnattendedInstall)], out var useUnattendedInstall);
         _ = bool.TryParse(request.Query[nameof(PackagesViewModel.OnelinerOutput)], out var onelinerOutput);
@@ -16,6 +17,7 @@ public class QueryStringService : IQueryStringService
         {
             includeStarterKit = true;
             installUmbracoTemplate = true;
+            forceTemplateInstall = true;
             createSolutionFile = true;
             useUnattendedInstall = true;
             onelinerOutput = false;
@@ -37,6 +39,7 @@ public class QueryStringService : IQueryStringService
             Packages = packages,
             InstallUmbracoTemplate = installUmbracoTemplate,
             UmbracoTemplateVersion = umbracoTemplateVersion,
+            ForceTemplateInstall = forceTemplateInstall,
             IncludeStarterKit = includeStarterKit,
             StarterKitPackage = starterKitPackage,
             UseUnattendedInstall = useUnattendedInstall,
@@ -59,6 +62,7 @@ public class QueryStringService : IQueryStringService
 
         queryString = queryString.Add(nameof(model.InstallUmbracoTemplate), model.InstallUmbracoTemplate.ToString());
         queryString = queryString.AddValueIfNotEmpty(nameof(model.UmbracoTemplateVersion), model.UmbracoTemplateVersion ?? "");
+        queryString = queryString.Add(nameof(model.ForceTemplateInstall), model.ForceTemplateInstall.ToString());
         queryString = queryString.Add(nameof(model.IncludeStarterKit), model.IncludeStarterKit.ToString());
         queryString = queryString.AddValueIfNotEmpty(nameof(model.StarterKitPackage), model.StarterKitPackage ?? "");
         queryString = queryString.Add(nameof(model.UseUnattendedInstall), model.UseUnattendedInstall.ToString());

--- a/PSW/PSW/Services/ScriptGeneratorService.cs
+++ b/PSW/PSW/Services/ScriptGeneratorService.cs
@@ -41,6 +41,8 @@ public class ScriptGeneratorService : IScriptGeneratorService
     {
         
         var outputList = new List<string>();
+        var forceTemplateInstallCommand = model.ForceTemplateInstall ? " --force" : "";
+        var installCommand = model.UmbracoTemplateVersion?.StartsWith("9.") == true || model.UmbracoTemplateVersion?.StartsWith("10.") == true ? "-i" : "install";
 
         if (!model.OnelinerOutput)
         {
@@ -49,13 +51,14 @@ public class ScriptGeneratorService : IScriptGeneratorService
         
         if (!string.IsNullOrWhiteSpace(model.UmbracoTemplateVersion))
         {
-            outputList.Add($"dotnet new -i Umbraco.Templates::{model.UmbracoTemplateVersion}");
+            outputList.Add($"dotnet new {installCommand} Umbraco.Templates::{model.UmbracoTemplateVersion}{forceTemplateInstallCommand}");
         }
         else
         {
-            outputList.Add("dotnet new -i Umbraco.Templates");
+            outputList.Add($"dotnet new {installCommand} Umbraco.Templates{forceTemplateInstallCommand}");
         }
-        
+
+
         outputList.Add("");
 
         return outputList;

--- a/PSW/PSW/Views/Home/Components/Packages/Default.cshtml
+++ b/PSW/PSW/Views/Home/Components/Packages/Default.cshtml
@@ -148,13 +148,19 @@
                             <label asp-for="@Model.UmbracoTemplateVersion"></label>
                             @if(Model.UmbracoVersions != null && Model.UmbracoVersions.Any())
                             {
-                                <select class="form-control" id="UmbracoTemplateVersion" name="UmbracoTemplateVersion" disabled="@(Model.InstallUmbracoTemplate ? null : "disabled")">
-                                    <option selected="@(Model.UmbracoTemplateVersion == "" ? "selected" : null)" value="">Latest Stable</option>
-                                    @foreach(var version in Model.UmbracoVersions)
-                                    {
-                                        <option selected="@(Model.UmbracoTemplateVersion == version ? "selected" : null)" value="@version">@version</option>
-                                    }
-                                </select>
+                                <div id="umbraco-template-version">
+                                    <select class="form-control" id="UmbracoTemplateVersion" name="UmbracoTemplateVersion" disabled="@(Model.InstallUmbracoTemplate ? null : "disabled")">
+                                        <option selected="@(Model.UmbracoTemplateVersion == "" ? "selected" : null)" value="">Latest Stable</option>
+                                        @foreach(var version in Model.UmbracoVersions)
+                                        {
+                                            <option selected="@(Model.UmbracoTemplateVersion == version ? "selected" : null)" value="@version">@version</option>
+                                        }
+                                    </select>
+                                    <div class="form-check">
+                                        <label asp-for="@Model.ForceTemplateInstall" class="form-check-label"></label>
+                                        <input asp-for="@Model.ForceTemplateInstall" class="form-check-input" type="checkbox" />
+                                    </div>
+                                </div>
                             }
                             else
                             {

--- a/PSW/PSW/wwwroot/css/style.css
+++ b/PSW/PSW/wwwroot/css/style.css
@@ -76,3 +76,14 @@ div.tab-pane p a {
     text-decoration: underline;
     font-weight: bold;
 }
+
+#umbraco-template-version {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px;
+    align-items: center;
+}
+
+    #umbraco-template-version select {
+        flex: 1;
+    }

--- a/PSW/PSW/wwwroot/js/site.js
+++ b/PSW/PSW/wwwroot/js/site.js
@@ -3,6 +3,7 @@
         packages: document.getElementById('Packages'),
         installUmbracoTemplate: document.getElementById('InstallUmbracoTemplate'),
         umbracoTemplateVersion: document.getElementById('UmbracoTemplateVersion'),
+        forceTemplateInstall: document.getElementById('ForceTemplateInstall'),
         includeStarterKit: document.getElementById('IncludeStarterKit'),
         starterKitPackage: document.getElementById('StarterKitPackage'),
         createSolutionFile: document.getElementById('CreateSolutionFile'),
@@ -79,6 +80,11 @@
 
         psw.controls.includeStarterKit.addEventListener('change', function () {
             psw.toggleIncludeStarterKitControls();
+            psw.updateOutput();
+            psw.updateUrl();
+        });
+
+        psw.controls.forceTemplateInstall.addEventListener('change', function () {
             psw.updateOutput();
             psw.updateUrl();
         });
@@ -182,6 +188,11 @@
         });
 
         psw.controls.includeStarterKit.addEventListener('change', function () {
+            psw.updateOutput();
+            psw.updateUrl();
+        });
+
+        psw.controls.forceTemplateInstall.addEventListener('change', function () {
             psw.updateOutput();
             psw.updateUrl();
         });
@@ -336,6 +347,7 @@
         }
         psw.controls.installUmbracoTemplate.checked = true;
         psw.controls.umbracoTemplateVersion.value = '';
+        psw.controls.forceTemplateInstall.checked = true;
         psw.controls.includeStarterKit.checked = true;
         psw.controls.starterKitPackage.value = 'clean';
         psw.controls.createSolutionFile.checked = true;
@@ -366,6 +378,7 @@
 
         psw.controls.installUmbracoTemplate.checked = searchParams.get("InstallUmbracoTemplate") === "true";
         psw.controls.umbracoTemplateVersion.value = searchParams.get("UmbracoTemplateVersion");
+        psw.controls.forceTemplateInstall.checked = searchParams.get("ForceTemplateInstall") === "true";
         psw.controls.includeStarterKit.checked = searchParams.get("IncludeStarterKit") === "true";
         psw.controls.starterKitPackage.value = searchParams.get("StarterKitPackage");
         psw.controls.createSolutionFile.checked = searchParams.get("CreateSolutionFile") === "true";
@@ -381,6 +394,7 @@
 
         psw.controls.umbracoTemplateVersion.disabled = !psw.controls.installUmbracoTemplate.checked;
         psw.controls.starterKitPackage.disabled = !psw.controls.includeStarterKit.checked;
+        psw.controls.forceTemplateInstall.disabled = !psw.controls.forceTemplateInstall.checked;
         psw.controls.solutionName.disabled = !psw.controls.createSolutionFile.checked;
         psw.controls.databaseType.disabled = !psw.controls.useUnattendedInstall.checked;
         psw.controls.userFriendlyName.disabled = !psw.controls.useUnattendedInstall.checked;
@@ -466,6 +480,7 @@
         var data = {
             "InstallUmbracoTemplate": psw.controls.installUmbracoTemplate.checked,
             "UmbracoTemplateVersion": psw.controls.umbracoTemplateVersion.value,
+            "ForceTemplateInstall": psw.controls.forceTemplateInstall.checked,
             "Packages": psw.controls.packages.value,
             "UserEmail": psw.controls.userEmail.value,
             "ProjectName": psw.controls.projectName.value,
@@ -513,6 +528,7 @@
             var searchParams = new URLSearchParams(window.location.search);
             searchParams.set("InstallUmbracoTemplate", psw.controls.installUmbracoTemplate.checked);
             searchParams.set("UmbracoTemplateVersion", psw.controls.umbracoTemplateVersion.value);
+            searchParams.set("ForceTemplateInstall", psw.controls.forceTemplateInstall.checked);
             searchParams.set("Packages", psw.controls.packages.value);
             searchParams.set("UserEmail", psw.controls.userEmail.value);
             searchParams.set("ProjectName", psw.controls.projectName.value);


### PR DESCRIPTION
Updated the `dotnet new` command for installing Umbraco.Templates to use the new `dotnet new install` syntax introduced as of .Net 7.0 (for Umbraco 11+). `dotnet new -i` is still used for v9 & v10 to maintain backward compatibility.

In addition, added the optional `--force` argument to overcome any installation errors if the same version is already installed on the machine. In the event of an error, this caused the remainder of the script to fail to run. The solution to this was to modify the script post script generation to add `--force` or remove the `dotnet new -i Umbraco.Template` all together. 
I've added this as a checkbox option which can omit the `-force` argument if not needed.

This is in relation to: Issue https://github.com/prjseal/Package-Script-Writer/issues/31