### PR TITLE
Community Templates

### DIFF
--- a/PSW/PSW/Constants/DefaultValues.cs
+++ b/PSW/PSW/Constants/DefaultValues.cs
@@ -1,6 +1,7 @@
 ﻿namespace PSW.Constants;
 public static class DefaultValues
 {
+    public const string TemplateName = GlobalConstants.TEMPLATE_NAME_UMBRACO;
     public const string StarterKitPackage = "clean";
     public const string ProjectName = "MyProject";
     public const string SolutionName = "MySolution";

--- a/PSW/PSW/Constants/GlobalConstants.cs
+++ b/PSW/PSW/Constants/GlobalConstants.cs
@@ -1,0 +1,7 @@
+﻿namespace PSW.Constants
+{
+    public class GlobalConstants
+    {
+        public const string TEMPLATE_NAME_UMBRACO = "Umbraco.Templates";
+    }
+}

--- a/PSW/PSW/Controllers/ScriptGeneratorApiController.cs
+++ b/PSW/PSW/Controllers/ScriptGeneratorApiController.cs
@@ -1,6 +1,7 @@
 ﻿using PSW.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.AspNetCore.Mvc.Rendering;
 
 namespace PSW.Controllers;
 
@@ -27,14 +28,13 @@ public class ScriptGeneratorApiController : ControllerBase
         if (apiRequest.IsEmpty)
         {
             apiRequest.IncludeStarterKit = true;
-            apiRequest.InstallUmbracoTemplate = true;
             apiRequest.CreateSolutionFile = true;
             apiRequest.UseUnattendedInstall = true;
             apiRequest.OnelinerOutput = false;
         }
 
         apiRequest.StarterKitPackage = !string.IsNullOrWhiteSpace(apiRequest.StarterKitPackage) ? apiRequest.StarterKitPackage : DefaultValues.StarterKitPackage;
-        apiRequest.ProjectName = !string.IsNullOrWhiteSpace(apiRequest.ProjectName) ? apiRequest.ProjectName : (apiRequest.CreateSolutionFile || apiRequest.InstallUmbracoTemplate ? PSW.Constants.DefaultValues.ProjectName : "");
+        apiRequest.ProjectName = !string.IsNullOrWhiteSpace(apiRequest.ProjectName) ? apiRequest.ProjectName : (apiRequest.CreateSolutionFile || apiRequest.TemplateName?.Equals(GlobalConstants.TEMPLATE_NAME_UMBRACO) == true ? PSW.Constants.DefaultValues.ProjectName : "");
         apiRequest.SolutionName = !string.IsNullOrWhiteSpace(apiRequest.SolutionName) ? apiRequest.SolutionName : DefaultValues.SolutionName;
         apiRequest.DatabaseType = !string.IsNullOrWhiteSpace(apiRequest.DatabaseType) ? apiRequest.DatabaseType : DefaultValues.DatabaseType;
         apiRequest.ConnectionString = !string.IsNullOrWhiteSpace(apiRequest.ConnectionString) ? apiRequest.ConnectionString : DefaultValues.ConnectionString;
@@ -43,6 +43,7 @@ public class ScriptGeneratorApiController : ControllerBase
         apiRequest.UserPassword = !string.IsNullOrWhiteSpace(apiRequest.UserPassword) ? apiRequest.UserPassword : DefaultValues.UserPassword;
 
         var model = new PackagesViewModel(apiRequest);
+
         return Ok(_scriptGeneratorService.GenerateScript(model));
     }
 

--- a/PSW/PSW/Dictionaries/TemplateDictionary.cs
+++ b/PSW/PSW/Dictionaries/TemplateDictionary.cs
@@ -1,0 +1,29 @@
+﻿namespace PSW.Dictionaries
+{
+    public class TemplateDictionary
+    {
+        public Dictionary<string, string> ShortNames
+        {
+            get
+            {
+                return new Dictionary<string, string>
+                {
+                    { "Umbraco.Community.Templates.UmBootstrap", "umbootstrap" },
+                    { "UmbCheckout.StarterKit.Stripe", "umbcheckout.starterkit.stripe" }
+                };
+            }
+        }
+
+        public string GetShortName(string key)
+        {
+            if (ShortNames.ContainsKey(key))
+            {
+                return ShortNames[key];
+            }
+            else
+            {
+                return key.ToLower();
+            }
+        }
+    }
+}

--- a/PSW/PSW/Enums/GlobalEnums.cs
+++ b/PSW/PSW/Enums/GlobalEnums.cs
@@ -1,0 +1,11 @@
+﻿namespace PSW.Enums
+{
+    public class GlobalEnums
+    {
+        public enum UmbracoMarketplaceQueryType
+        {
+            Packages,
+            Templates,
+        }
+    }
+}

--- a/PSW/PSW/Extensions/QueryCollectionExtensions.cs
+++ b/PSW/PSW/Extensions/QueryCollectionExtensions.cs
@@ -14,4 +14,17 @@ public static class QueryCollectionExtensions
 
         return returnValue;
     }
+
+    public static int GetIntValue(this IQueryCollection query, string keyName, int fallbackValue)
+    {
+        var rawValue = query[keyName];
+
+        if (!string.IsNullOrWhiteSpace(rawValue) && int.TryParse(rawValue, out var parsedValue))
+        {
+            return parsedValue;
+        }
+
+        return fallbackValue;
+    }
+
 }

--- a/PSW/PSW/GlobalUsings.cs
+++ b/PSW/PSW/GlobalUsings.cs
@@ -1,2 +1,4 @@
-﻿global using PSW.Constants;
+﻿global using PSW;
+global using PSW.Constants;
 global using PSW.Services;
+global using PSW.Enums;

--- a/PSW/PSW/Models/GeneratorApiRequest.cs
+++ b/PSW/PSW/Models/GeneratorApiRequest.cs
@@ -1,20 +1,23 @@
 ﻿namespace PSW.Models;
-
 public class GeneratorApiRequest
 {
     public bool IsEmpty
     {
         get
         {
-            return !InstallUmbracoTemplate && !CreateSolutionFile
+            return string.IsNullOrWhiteSpace(TemplateName) && !CreateSolutionFile
                 && !IncludeStarterKit && !UseUnattendedInstall
-                && string.IsNullOrWhiteSpace(UmbracoTemplateVersion + Packages
+                && TemplateName?.Equals(GlobalConstants.TEMPLATE_NAME_UMBRACO) == true && string.IsNullOrWhiteSpace(TemplateVersion + Packages
                 + SolutionName + ProjectName + UserFriendlyName + UserEmail
-                + UserPassword + StarterKitPackage + DatabaseType);
+                + UserPassword + StarterKitPackage + DatabaseType)
+                && !string.IsNullOrWhiteSpace(TemplateName) && !TemplateName.Equals(GlobalConstants.TEMPLATE_NAME_UMBRACO) &&
+                string.IsNullOrWhiteSpace(TemplateVersion + Packages
+                + SolutionName + ProjectName + UserFriendlyName + UserEmail
+                + UserPassword + DatabaseType);
         }
     }
-    public bool InstallUmbracoTemplate { get; set; }
-    public string? UmbracoTemplateVersion { get; set; }
+    public string? TemplateName { get; set; }
+    public string? TemplateVersion { get; set; }
     public string? Packages { get; set; }
     public bool CreateSolutionFile { get; set; }
     public string? SolutionName { get; set; }

--- a/PSW/PSW/Models/PackagesViewModel.cs
+++ b/PSW/PSW/Models/PackagesViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using static PSW.Models.PackageFeed;
+using Microsoft.AspNetCore.Mvc.Rendering;
 
 namespace PSW.Models;
 public class PackagesViewModel
@@ -8,8 +9,8 @@ public class PackagesViewModel
 
     public PackagesViewModel(GeneratorApiRequest apiRequest)
     {
-        InstallUmbracoTemplate = apiRequest.InstallUmbracoTemplate;
-        UmbracoTemplateVersion = apiRequest.UmbracoTemplateVersion;
+        TemplateName = apiRequest.TemplateName;
+        TemplateVersion = apiRequest.TemplateVersion;
         CreateSolutionFile = apiRequest.CreateSolutionFile;
         SolutionName = apiRequest.SolutionName;
         ProjectName = apiRequest.ProjectName;
@@ -25,12 +26,13 @@ public class PackagesViewModel
         OnelinerOutput = apiRequest.OnelinerOutput;
     }
 
+    public List<SelectListItem> TemplateNames { get; set; }
 
-    [Display(Name = "Install an Umbraco Template:")]
-    public bool InstallUmbracoTemplate { get; set; }
+    [Display(Name = "Template Name:")]
+    public string TemplateName { get; set; }
 
-    [Display(Name = "Umbraco Template Version:")]
-    public string? UmbracoTemplateVersion { get; set; }
+    [Display(Name = "Template Version:")]
+    public string? TemplateVersion { get; set; }
 
     public List<PagedPackagesPackage>? AllPackages { get; set; }
     public string? Packages { get; set; }

--- a/PSW/PSW/Services/IPackageService.cs
+++ b/PSW/PSW/Services/IPackageService.cs
@@ -1,5 +1,6 @@
 ﻿using PSW.Models;
 using PSW.Models.NuGet;
+using static PSW.Enums.GlobalEnums;
 
 namespace PSW.Services;
 
@@ -8,4 +9,6 @@ public interface IPackageService
     List<string> GetNugetPackageVersions(string packageUrl);
     public List<string> GetPackageVersions(string packageUrl);
     public List<PagedPackagesPackage> GetAllPackagesFromUmbraco();
+    List<PagedPackagesPackage> GetFromUmbracoMarketplace(UmbracoMarketplaceQueryType umbracoMarketplaceQueryType);
+    List<PagedPackagesPackage> GetAllTemplatesFromUmbraco();
 }

--- a/PSW/PSW/Services/MarketplacePackageService.cs
+++ b/PSW/PSW/Services/MarketplacePackageService.cs
@@ -3,6 +3,7 @@ using PSW.Models.NuGet;
 using System.Text.Json;
 using System.Xml;
 using System.Xml.Serialization;
+using static PSW.Enums.GlobalEnums;
 
 namespace PSW.Services
 {
@@ -58,6 +59,16 @@ namespace PSW.Services
 
         public List<PagedPackagesPackage> GetAllPackagesFromUmbraco()
         {
+            return GetFromUmbracoMarketplace(UmbracoMarketplaceQueryType.Packages);
+        }
+
+        public List<PagedPackagesPackage> GetAllTemplatesFromUmbraco()
+        {
+            return GetFromUmbracoMarketplace(UmbracoMarketplaceQueryType.Templates);
+        }
+
+        public List<PagedPackagesPackage> GetFromUmbracoMarketplace(UmbracoMarketplaceQueryType umbracoMarketplaceQueryType)
+        {
             int pageIndex = 1;
             var pageSize = 50;
             var carryOn = true;
@@ -72,8 +83,13 @@ namespace PSW.Services
                 {
                     pageSize = total - totalSoFar;
                 }
-
-                var url = $"https://api.marketplace.umbraco.com/api/v1.0/packages?orderBy=MostDownloads&fields=numberOfNuGetDownloads,authors,packageType,licenseTypes,iconUrl,minimumUmbracoVersionNumber,maximumUmbracoVersionNumber,isCertifiedToWorkOnUmbracoCloud,isPromoted,isPartner,isHQ,isHQSupported,id,title,description,packageId,tags,umbracoMajorVersionsSupported,iconDominantColor,Category&pageSize={pageSize}&pageNumber={pageIndex}";
+                
+                string url = umbracoMarketplaceQueryType switch
+                {
+                    UmbracoMarketplaceQueryType.Packages => $"https://api.marketplace.umbraco.com/api/v1.0/packages?orderBy=MostDownloads&fields=numberOfNuGetDownloads,authors,packageType,licenseTypes,iconUrl,minimumUmbracoVersionNumber,maximumUmbracoVersionNumber,isCertifiedToWorkOnUmbracoCloud,isPromoted,isPartner,isHQ,isHQSupported,id,title,description,packageId,tags,umbracoMajorVersionsSupported,iconDominantColor,Category&pageSize={pageSize}&pageNumber={pageIndex}",
+                    UmbracoMarketplaceQueryType.Templates => $"https://api.marketplace.umbraco.com/api/v1.0/packages?packageType=Template&categoryId=b239f1b7-31f6-4665-bf03-2ab985c64ac0&fields=title,packageId&pageSize={pageSize}&pageNumber={pageIndex}",
+                    _ => throw new Exception("Unable to match to a marketplace query type")
+                };
 
                 try
                 {

--- a/PSW/PSW/Services/QueryStringService.cs
+++ b/PSW/PSW/Services/QueryStringService.cs
@@ -7,7 +7,7 @@ public class QueryStringService : IQueryStringService
     public PackagesViewModel LoadModelFromQueryString(HttpRequest request)
     {
         _ = bool.TryParse(request.Query[nameof(PackagesViewModel.IncludeStarterKit)], out var includeStarterKit);
-        _ = bool.TryParse(request.Query[nameof(PackagesViewModel.InstallUmbracoTemplate)], out var installUmbracoTemplate);
+        _ = bool.TryParse(request.Query["InstallUmbracoTemplate"], out var installUmbracoTemplate); // Fallback
         _ = bool.TryParse(request.Query[nameof(PackagesViewModel.CreateSolutionFile)], out var createSolutionFile);
         _ = bool.TryParse(request.Query[nameof(PackagesViewModel.UseUnattendedInstall)], out var useUnattendedInstall);
         _ = bool.TryParse(request.Query[nameof(PackagesViewModel.OnelinerOutput)], out var onelinerOutput);
@@ -15,13 +15,14 @@ public class QueryStringService : IQueryStringService
         if (request.Query.Count == 0)
         {
             includeStarterKit = true;
-            installUmbracoTemplate = true;
             createSolutionFile = true;
             useUnattendedInstall = true;
             onelinerOutput = false;
         }
 
-        var umbracoTemplateVersion = request.Query.GetStringValue(nameof(PackagesViewModel.UmbracoTemplateVersion), "");
+        var templateName = installUmbracoTemplate ? GlobalConstants.TEMPLATE_NAME_UMBRACO : request.Query.GetStringValue("TemplateName", DefaultValues.TemplateName);
+        var umbracoTemplateVersion = request.Query.GetStringValue("UmbracoTemplateVersion", ""); // Fallback
+        var templateVersion = string.IsNullOrEmpty(umbracoTemplateVersion) ? request.Query.GetStringValue(nameof(PackagesViewModel.TemplateVersion), "") : "";
         var starterKitPackage = request.Query.GetStringValue(nameof(PackagesViewModel.StarterKitPackage), DefaultValues.StarterKitPackage);
         var projectName = request.Query.GetStringValue(nameof(PackagesViewModel.ProjectName), createSolutionFile || installUmbracoTemplate ? DefaultValues.ProjectName : "");
         var solutionName = request.Query.GetStringValue(nameof(PackagesViewModel.SolutionName), DefaultValues.SolutionName);
@@ -35,8 +36,8 @@ public class QueryStringService : IQueryStringService
         var packageOptions = new PackagesViewModel()
         {
             Packages = packages,
-            InstallUmbracoTemplate = installUmbracoTemplate,
-            UmbracoTemplateVersion = umbracoTemplateVersion,
+            TemplateName = templateName,
+            TemplateVersion = templateVersion,
             IncludeStarterKit = includeStarterKit,
             StarterKitPackage = starterKitPackage,
             UseUnattendedInstall = useUnattendedInstall,
@@ -57,8 +58,8 @@ public class QueryStringService : IQueryStringService
     {
         var queryString = new QueryString();
 
-        queryString = queryString.Add(nameof(model.InstallUmbracoTemplate), model.InstallUmbracoTemplate.ToString());
-        queryString = queryString.AddValueIfNotEmpty(nameof(model.UmbracoTemplateVersion), model.UmbracoTemplateVersion ?? "");
+        queryString = queryString.Add(nameof(model.TemplateName), model.TemplateName ?? "");
+        queryString = queryString.AddValueIfNotEmpty(nameof(model.TemplateVersion), model.TemplateVersion ?? "");
         queryString = queryString.Add(nameof(model.IncludeStarterKit), model.IncludeStarterKit.ToString());
         queryString = queryString.AddValueIfNotEmpty(nameof(model.StarterKitPackage), model.StarterKitPackage ?? "");
         queryString = queryString.Add(nameof(model.UseUnattendedInstall), model.UseUnattendedInstall.ToString());

--- a/PSW/PSW/Services/ScriptGeneratorService.cs
+++ b/PSW/PSW/Services/ScriptGeneratorService.cs
@@ -1,4 +1,5 @@
-﻿using PSW.Models;
+﻿using PSW.Dictionaries;
+using PSW.Models;
 
 namespace PSW.Services;
 public class ScriptGeneratorService : IScriptGeneratorService
@@ -9,7 +10,7 @@ public class ScriptGeneratorService : IScriptGeneratorService
 
         var renderPackageName = !string.IsNullOrWhiteSpace(model.ProjectName);
 
-        if (model.InstallUmbracoTemplate)
+        if (!string.IsNullOrWhiteSpace(model.TemplateName))
         {
             outputList.AddRange(GenerateUmbracoTemplatesSectionScript(model));
 
@@ -22,7 +23,10 @@ public class ScriptGeneratorService : IScriptGeneratorService
             outputList.Add("");
         }
 
-        outputList.AddRange(GenerateAddStarterKitScript(model, renderPackageName));
+        if (model.TemplateName.Equals(GlobalConstants.TEMPLATE_NAME_UMBRACO))
+        {
+            outputList.AddRange(GenerateAddStarterKitScript(model, renderPackageName));
+        }
 
         outputList.AddRange(GenerateAddPackagesScript(model, renderPackageName));
 
@@ -32,30 +36,39 @@ public class ScriptGeneratorService : IScriptGeneratorService
         {
             return string.Join(Environment.NewLine, outputList);
         }
-        
+
         outputList.RemoveAll(string.IsNullOrWhiteSpace);
         return string.Join(" && ", outputList);
     }
 
     public List<string> GenerateUmbracoTemplatesSectionScript(PackagesViewModel model)
     {
-        
         var outputList = new List<string>();
+        var templateName = model.TemplateName;
 
-        if (!model.OnelinerOutput)
+        if (!string.IsNullOrEmpty(templateName))
         {
-            outputList.Add("# Ensure we have the latest Umbraco templates");
+
+            if (!string.IsNullOrWhiteSpace(model.TemplateVersion))
+            {
+                if (!model.OnelinerOutput)
+                {
+                    outputList.Add(templateName.Equals(GlobalConstants.TEMPLATE_NAME_UMBRACO) ? "# Ensure we have the version specific Umbraco templates" : "# Ensure we have the version specific Community templates");
+                }
+
+                outputList.Add($"dotnet new -i {templateName}::{model.TemplateVersion} --force");
+            }
+            else
+            {
+                if (!model.OnelinerOutput)
+                {
+                    outputList.Add(templateName.Equals(GlobalConstants.TEMPLATE_NAME_UMBRACO) ? "# Ensure we have the latest Umbraco templates" : "# Ensure we have the latest Community templates");
+                }
+
+                outputList.Add($"dotnet new -i {templateName} --force");
+            }
         }
-        
-        if (!string.IsNullOrWhiteSpace(model.UmbracoTemplateVersion))
-        {
-            outputList.Add($"dotnet new -i Umbraco.Templates::{model.UmbracoTemplateVersion}");
-        }
-        else
-        {
-            outputList.Add("dotnet new -i Umbraco.Templates");
-        }
-        
+
         outputList.Add("");
 
         return outputList;
@@ -83,7 +96,8 @@ public class ScriptGeneratorService : IScriptGeneratorService
     {
         var outputList = new List<string>();
 
-        var majorVersionNumberAsString = model.UmbracoTemplateVersion.Split('.').FirstOrDefault();
+        var installUmbracoTemplate = model.TemplateName.Equals(GlobalConstants.TEMPLATE_NAME_UMBRACO);
+        var majorVersionNumberAsString = model.TemplateVersion?.Split('.').FirstOrDefault();
         var majorVersionNumber = 10;
 
         if (!string.IsNullOrWhiteSpace(majorVersionNumberAsString))
@@ -91,63 +105,68 @@ public class ScriptGeneratorService : IScriptGeneratorService
             _ = int.TryParse(majorVersionNumberAsString, out majorVersionNumber);
         }
 
-        var isOldv10RCVersion = model.UmbracoTemplateVersion == "10.0.0-rc1" || model.UmbracoTemplateVersion == "10.0.0-rc2" || model.UmbracoTemplateVersion == "10.0.0-rc3";
-        var isV10OrAbove = majorVersionNumber >= 10;
+        var isOldv10RCVersion = installUmbracoTemplate && (model.TemplateVersion == "10.0.0-rc1" || model.TemplateVersion == "10.0.0-rc2" || model.TemplateVersion == "10.0.0-rc3");
+        var isV10OrAbove = installUmbracoTemplate && majorVersionNumber >= 10;
 
-        if (model.UseUnattendedInstall)
+        if (installUmbracoTemplate)
         {
-            var connectionString = "";
-            var databasTypeSwitch = "";
-            switch (model.DatabaseType)
+            if (model.UseUnattendedInstall)
             {
-                case "SQLCE":
-                    if (majorVersionNumber == 9)
-                    {
-                        connectionString = "--connection-string \"Data Source=|DataDirectory|\\Umbraco.sdf;Flush Interval=1\" -ce";
-                    }
-                    break;
-                case "LocalDb":
-                    if (!isV10OrAbove || isOldv10RCVersion)
-                    {
-                        connectionString = " --connection-string \"Data Source = (localdb)\\MSSQLLocalDB;AttachDbFilename=|DataDirectory|\\Umbraco.mdf;Integrated Security=True\"";
-                    }
-                    else if (isV10OrAbove && !isOldv10RCVersion)
-                    {
-                        databasTypeSwitch = " --development-database-type LocalDB";
-                    }
-                    break;
-                case "SQLite":
-                    if (!isV10OrAbove || isOldv10RCVersion)
-                    {
-                        connectionString = " --connection-string \"Data Source=|DataDirectory|/Umbraco.sqlite.db;Cache=Shared;Foreign Keys=True;Pooling=True\"";
-                    }
-                    else if (isV10OrAbove && !isOldv10RCVersion)
-                    {
-                        databasTypeSwitch = " --development-database-type SQLite";
-                    }
-                    break;
-                case "SQLAzure":
-                case "SQLServer":
-                    connectionString = $" --connection-string \"{model.ConnectionString}\" --connection-string-provider-name \"Microsoft.Data.SqlClient\"";
-                    break;
-                default:
-                    break;
+                var connectionString = "";
+                var databasTypeSwitch = "";
+                switch (model.DatabaseType)
+                {
+                    case "SQLCE":
+                        if (majorVersionNumber == 9)
+                        {
+                            connectionString = "--connection-string \"Data Source=|DataDirectory|\\Umbraco.sdf;Flush Interval=1\" -ce";
+                        }
+                        break;
+                    case "LocalDb":
+                        if (!isV10OrAbove || isOldv10RCVersion)
+                        {
+                            connectionString = " --connection-string \"Data Source = (localdb)\\MSSQLLocalDB;AttachDbFilename=|DataDirectory|\\Umbraco.mdf;Integrated Security=True\"";
+                        }
+                        else if (isV10OrAbove && !isOldv10RCVersion)
+                        {
+                            databasTypeSwitch = " --development-database-type LocalDB";
+                        }
+                        break;
+                    case "SQLite":
+                        if (!isV10OrAbove || isOldv10RCVersion)
+                        {
+                            connectionString = " --connection-string \"Data Source=|DataDirectory|/Umbraco.sqlite.db;Cache=Shared;Foreign Keys=True;Pooling=True\"";
+                        }
+                        else if (isV10OrAbove && !isOldv10RCVersion)
+                        {
+                            databasTypeSwitch = " --development-database-type SQLite";
+                        }
+                        break;
+                    case "SQLAzure":
+                    case "SQLServer":
+                        connectionString = $" --connection-string \"{model.ConnectionString}\" --connection-string-provider-name \"Microsoft.Data.SqlClient\"";
+                        break;
+                    default:
+                        break;
+                }
+
+                outputList.Add($"dotnet new umbraco --force -n \"{model.ProjectName}\" --friendly-name \"{model.UserFriendlyName}\" --email \"{model.UserEmail}\" --password \"{model.UserPassword}\"{connectionString}{databasTypeSwitch}");
+
+                if (model.DatabaseType == "SQLite" && isOldv10RCVersion)
+                {
+                    outputList.Add("$env:Umbraco__CMS__Global__InstallMissingDatabase=\"true\"");
+                    outputList.Add("$env:ConnectionStrings__umbracoDbDSN_ProviderName=\"Microsoft.Data.SQLite\"");
+                }
             }
-
-            outputList.Add($"dotnet new umbraco --force -n \"{model.ProjectName}\" --friendly-name \"{model.UserFriendlyName}\" --email \"{model.UserEmail}\" --password \"{model.UserPassword}\"{connectionString}{databasTypeSwitch}");
-
-            if (model.DatabaseType == "SQLite" && isOldv10RCVersion)
+            else
             {
-                outputList.Add("$env:Umbraco__CMS__Global__InstallMissingDatabase=\"true\"");
-                outputList.Add("$env:ConnectionStrings__umbracoDbDSN_ProviderName=\"Microsoft.Data.SQLite\"");
+                outputList.Add($"dotnet new umbraco --force -n \"{model.ProjectName}\"");
             }
         }
         else
         {
-            outputList.Add($"dotnet new umbraco --force -n \"{model.ProjectName}\"");
+            outputList.Add($"dotnet new {new TemplateDictionary().GetShortName(model.TemplateName)} --force -n \"{model.ProjectName}\"");
         }
-
-
 
         return outputList;
     }
@@ -169,7 +188,7 @@ public class ScriptGeneratorService : IScriptGeneratorService
         var outputList = new List<string>();
 
         if (!model.IncludeStarterKit) return outputList;
-        
+
         if (!model.OnelinerOutput)
         {
             outputList.Add("#Add starter kit");
@@ -183,7 +202,7 @@ public class ScriptGeneratorService : IScriptGeneratorService
         {
             outputList.Add($"dotnet add package {model.StarterKitPackage}");
         }
-        
+
         outputList.Add("");
 
         return outputList;
@@ -194,7 +213,7 @@ public class ScriptGeneratorService : IScriptGeneratorService
         var outputList = new List<string>();
 
         if (string.IsNullOrWhiteSpace(model.Packages)) return outputList;
-        
+
         var packages = model.Packages.Split(',', System.StringSplitOptions.RemoveEmptyEntries);
 
         if (packages.Length > 0)

--- a/PSW/PSW/Views/Home/Components/Packages/Default.cshtml
+++ b/PSW/PSW/Views/Home/Components/Packages/Default.cshtml
@@ -2,6 +2,7 @@
 @using PSW.Extensions;
 @using PSW.Models
 @using PSW.Controllers
+@using System.ComponentModel.DataAnnotations;
 
 @{
     var hasQueryString = Context.Request.Query.Count > 0;
@@ -139,26 +140,26 @@
                 <div class="row">
                     <div class="col-6">
                         <div class="form-group pt-2">
-                            <div class="form-check">
-                                <label asp-for="@Model.InstallUmbracoTemplate" class="form-check-label"></label>
-                                <input asp-for="@Model.InstallUmbracoTemplate" class="form-check-input" type="checkbox" />
+                            <div style="display: flex; flex-wrap: wrap; column-gap: 30px;">
+                                <label asp-for="@Model.TemplateName" class="form-check-label" style="width: 100%;"></label>
+                                <select class="form-control" asp-for="@Model.TemplateName" asp-items="Model.TemplateNames"></select>
                             </div>
                         </div>
                         <div class="form-group py-2">
-                            <label asp-for="@Model.UmbracoTemplateVersion"></label>
+                            <label asp-for="@Model.TemplateVersion"></label>
                             @if(Model.UmbracoVersions != null && Model.UmbracoVersions.Any())
                             {
-                                <select class="form-control" id="UmbracoTemplateVersion" name="UmbracoTemplateVersion" disabled="@(Model.InstallUmbracoTemplate ? null : "disabled")">
-                                    <option selected="@(Model.UmbracoTemplateVersion == "" ? "selected" : null)" value="">Latest Stable</option>
+                                <select class="form-control" id="@nameof(Model.TemplateVersion)" name="@nameof(Model.TemplateVersion)" disabled="@(string.IsNullOrWhiteSpace(Model.TemplateName) ? "disabled" : null)">
+                                    <option selected="@(Model.TemplateVersion == "" ? "selected" : null)" value="">Latest Stable</option>
                                     @foreach(var version in Model.UmbracoVersions)
                                     {
-                                        <option selected="@(Model.UmbracoTemplateVersion == version ? "selected" : null)" value="@version">@version</option>
+                                        <option selected="@(Model.TemplateVersion == version ? "selected" : null)" value="@version">@version</option>
                                     }
                                 </select>
                             }
                             else
                             {
-                                <input asp-for="@Model.UmbracoTemplateVersion" class="form-control" disabled="@(Model.InstallUmbracoTemplate ? null : "disabled")" />                                
+                                <input asp-for="@Model.TemplateVersion" class="form-control" disabled="@(Model.TemplateName.Equals(GlobalConstants.TEMPLATE_NAME_UMBRACO) ? null : "disabled")" />
                             }
                         </div>
                         <div class="form-group pt-3">

--- a/PSW/PSW/wwwroot/js/site.js
+++ b/PSW/PSW/wwwroot/js/site.js
@@ -1,8 +1,8 @@
 ﻿var psw = psw || {
     controls: {
         packages: document.getElementById('Packages'),
-        installUmbracoTemplate: document.getElementById('InstallUmbracoTemplate'),
-        umbracoTemplateVersion: document.getElementById('UmbracoTemplateVersion'),
+        templateName: document.getElementById('TemplateName'),
+        templateVersion: document.getElementById('TemplateVersion'),
         includeStarterKit: document.getElementById('IncludeStarterKit'),
         starterKitPackage: document.getElementById('StarterKitPackage'),
         createSolutionFile: document.getElementById('CreateSolutionFile'),
@@ -71,8 +71,8 @@
             psw.updateUrl();
         });
         
-        psw.controls.installUmbracoTemplate.addEventListener('change', function () {
-            psw.toggleInstallUmbracoTemplateControls();
+        psw.controls.templateName.addEventListener('change', function () {
+            psw.toggleTemplateNameControls();
             psw.updateOutput();
             psw.updateUrl();
         });
@@ -176,7 +176,7 @@
             psw.updateUrl();
         }, 250));
 
-        psw.controls.installUmbracoTemplate.addEventListener('change', function () {
+        psw.controls.templateName.addEventListener('change', function () {
             psw.updateOutput();
             psw.updateUrl();
         });
@@ -196,7 +196,7 @@
             psw.updateUrl();
         });
 
-        psw.controls.umbracoTemplateVersion.addEventListener('change', function () {
+        psw.controls.templateVersion.addEventListener('change', function () {
             psw.updateOutput();
             psw.updateUrl();
         });
@@ -288,7 +288,7 @@
                 return result;
             }
         }).then((data) => {
-            console.log(data);
+            // console.log(data);
             
 
             var packageVersions = JSON.parse(data);
@@ -308,6 +308,67 @@
 
                 thisDropdown.appendChild(opt);
             }
+
+        }).catch((error) => {
+            console.log(error);
+        });
+    },
+    loadTemplateVersionDropdown: function () {
+        var templateName = psw.controls.templateName;
+        var templateVersion = psw.controls.templateVersion;
+        var nugetPackageId = templateName.value;
+
+        var data = {
+            "PackageId": nugetPackageId.toLowerCase()
+        }
+
+        var url = "/api/scriptgeneratorapi/getpackageversions";
+
+        fetch(url, {
+            method: 'POST', // *GET, POST, PUT, DELETE, etc.
+            mode: 'cors', // no-cors, *cors, same-origin
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(data) // body data type must match "Content-Type" header
+        }).then((response) => {
+            var result = response.text();
+            if (response.ok) {
+                return result;
+            }
+        }).then((data) => {
+            // console.log(data);
+
+            var packageVersions = JSON.parse(data);
+
+            templateVersion.innerHTML = '';
+
+            var latestStableOption = document.createElement('option');
+            latestStableOption.value = '';
+            latestStableOption.text = 'Latest Stable';
+            templateVersion.add(latestStableOption);
+
+            packageVersions.forEach(function (version) {
+                var option = document.createElement('option');
+                option.value = version;
+                option.text = version;
+                templateVersion.add(option);
+            });
+            //var optionPosition;
+            //var lastOptionPosition = thisDropdown.options.length - 1;
+            //for (optionPosition = lastOptionPosition; optionPosition > 1; optionPosition--) {
+            //    thisDropdown.remove(optionPosition);
+            //}
+
+            //var versionCount = packageVersions.length;
+            //for (i = 0; i < versionCount; i++) {
+            //    var version = packageVersions[i];
+            //    var opt = document.createElement("option");
+            //    opt.value = version;
+            //    opt.innerHTML = version;
+
+            //    thisDropdown.appendChild(opt);
+            //}
 
         }).catch((error) => {
             console.log(error);
@@ -334,8 +395,10 @@
         if(event !== undefined) {
             event.preventDefault();
         }
-        psw.controls.installUmbracoTemplate.checked = true;
-        psw.controls.umbracoTemplateVersion.value = '';
+
+        // console.log('reset');
+        psw.controls.templateName.value = 'Umbraco.Templates';
+        psw.controls.templateVersion.value = '';
         psw.controls.includeStarterKit.checked = true;
         psw.controls.starterKitPackage.value = 'clean';
         psw.controls.createSolutionFile.checked = true;
@@ -349,7 +412,7 @@
         psw.controls.databaseType.value = 'SQLite';
         psw.controls.onelinerOutput.checked = false;
         
-        psw.controls.umbracoTemplateVersion.removeAttribute('disabled');
+        psw.controls.templateVersion.removeAttribute('disabled');
         psw.controls.starterKitPackage.removeAttribute('disabled');
         psw.controls.solutionName.removeAttribute('disabled');
         psw.controls.databaseType.removeAttribute('disabled');
@@ -358,14 +421,23 @@
         psw.controls.userPassword.removeAttribute('disabled');
     },
     setFromLocalStorage: function () {
+
+        if ('URLSearchParams' in window) {
+            var urlQuery = new URLSearchParams(window.location.search);
+            var hasQueryStrings = (urlQuery.size > 0);
+            if (hasQueryStrings) {
+                return psw.setFromQueryString();
+            }
+        }
+
         if (window.localStorage.getItem("searchParams") == null) {
             return psw.reset();
         }
 
         var searchParams = new URLSearchParams(window.localStorage.getItem("searchParams"));
 
-        psw.controls.installUmbracoTemplate.checked = searchParams.get("InstallUmbracoTemplate") === "true";
-        psw.controls.umbracoTemplateVersion.value = searchParams.get("UmbracoTemplateVersion");
+        psw.controls.templateName.value = searchParams.get("TemplateName");
+        psw.controls.templateVersion.value = searchParams.get("TemplateVersion");
         psw.controls.includeStarterKit.checked = searchParams.get("IncludeStarterKit") === "true";
         psw.controls.starterKitPackage.value = searchParams.get("StarterKitPackage");
         psw.controls.createSolutionFile.checked = searchParams.get("CreateSolutionFile") === "true";
@@ -379,7 +451,7 @@
         psw.controls.databaseType.value = searchParams.get("DatabaseType");
         psw.controls.onelinerOutput.checked = searchParams.get("OnelinerOutput") === "true";
 
-        psw.controls.umbracoTemplateVersion.disabled = !psw.controls.installUmbracoTemplate.checked;
+        psw.controls.templateVersion.disabled = psw.controls.templateName.value === "";
         psw.controls.starterKitPackage.disabled = !psw.controls.includeStarterKit.checked;
         psw.controls.solutionName.disabled = !psw.controls.createSolutionFile.checked;
         psw.controls.databaseType.disabled = !psw.controls.useUnattendedInstall.checked;
@@ -389,6 +461,43 @@
 
         psw.updateOutput();
         psw.updateUrl();
+    },
+    setFromQueryString: function () {
+        var hasQueryStrings = false;
+        var searchParams = new URLSearchParams(window.location.search);
+
+        if ('URLSearchParams' in window) {
+            hasQueryStrings = (searchParams.size > 0);
+        }
+
+        if (!hasQueryStrings) {
+            return psw.reset();
+        }
+
+        psw.controls.templateName.value = searchParams.get("TemplateName");
+        psw.controls.templateVersion.value = searchParams.get("TemplateVersion");
+        psw.controls.includeStarterKit.checked = searchParams.get("IncludeStarterKit") === "true";
+        psw.controls.starterKitPackage.value = searchParams.get("StarterKitPackage");
+        psw.controls.createSolutionFile.checked = searchParams.get("CreateSolutionFile") === "true";
+        psw.controls.solutionName.value = searchParams.get("SolutionName");
+        psw.controls.projectName.value = searchParams.get("ProjectName");
+        psw.controls.useUnattendedInstall.checked = searchParams.get("UseUnattendedInstall") === "true";
+        psw.controls.connectionString.value = searchParams.get("ConnectionString");
+        psw.controls.userFriendlyName.value = searchParams.get("UserFriendlyName");
+        psw.controls.userEmail.value = searchParams.get("UserEmail");
+        psw.controls.userPassword.value = searchParams.get("UserPassword");
+        psw.controls.databaseType.value = searchParams.get("DatabaseType");
+        psw.controls.onelinerOutput.checked = searchParams.get("OnelinerOutput") === "true";
+
+        psw.controls.templateVersion.disabled = psw.controls.templateName.value === "";
+        psw.controls.starterKitPackage.disabled = !psw.controls.includeStarterKit.checked;
+        psw.controls.solutionName.disabled = !psw.controls.createSolutionFile.checked;
+        psw.controls.databaseType.disabled = !psw.controls.useUnattendedInstall.checked;
+        psw.controls.userFriendlyName.disabled = !psw.controls.useUnattendedInstall.checked;
+        psw.controls.userEmail.disabled = !psw.controls.useUnattendedInstall.checked;
+        psw.controls.userPassword.disabled = !psw.controls.useUnattendedInstall.checked;
+
+        psw.updateOutput();
     },
     filterPackages: function () {
         var filter, ul, li, a, i, txtValue;
@@ -422,12 +531,13 @@
             psw.controls.connectionString.setAttribute('disabled', 'disabled');
         }
     },
-    toggleInstallUmbracoTemplateControls: function () {
-        if (psw.controls.installUmbracoTemplate.checked) {
-            psw.controls.umbracoTemplateVersion.removeAttribute('disabled');
+    toggleTemplateNameControls: function () {
+        if (psw.controls.templateName.value !== '') {
+            psw.controls.templateVersion.removeAttribute('disabled');
+            psw.loadTemplateVersionDropdown();
         }
         else {
-            psw.controls.umbracoTemplateVersion.setAttribute('disabled', 'disabled');
+            psw.controls.templateVersion.setAttribute('disabled', 'disabled');
         }
     },
     toggleIncludeStarterKitControls: function () {
@@ -462,10 +572,11 @@
         navigator.clipboard.writeText(psw.controls.codeBlock.innerText);
     },
     updateOutput: function () {
+        psw.setFieldState();
 
         var data = {
-            "InstallUmbracoTemplate": psw.controls.installUmbracoTemplate.checked,
-            "UmbracoTemplateVersion": psw.controls.umbracoTemplateVersion.value,
+            "TemplateName": psw.controls.templateName.value,
+            "TemplateVersion": psw.controls.templateVersion.value,
             "Packages": psw.controls.packages.value,
             "UserEmail": psw.controls.userEmail.value,
             "ProjectName": psw.controls.projectName.value,
@@ -474,7 +585,6 @@
             "UseUnattendedInstall": psw.controls.useUnattendedInstall.checked,
             "DatabaseType": psw.controls.databaseType.value,
             "UserPassword": psw.controls.userPassword.value,
-            "UmbracoTemplateVersion": psw.controls.umbracoTemplateVersion.value,
             "ConnectionString": psw.controls.connectionString.value,
             "UserFriendlyName": psw.controls.userFriendlyName.value,
             "IncludeStarterKit": psw.controls.includeStarterKit.checked,
@@ -511,8 +621,8 @@
     updateUrl: function () {
         if ('URLSearchParams' in window) {
             var searchParams = new URLSearchParams(window.location.search);
-            searchParams.set("InstallUmbracoTemplate", psw.controls.installUmbracoTemplate.checked);
-            searchParams.set("UmbracoTemplateVersion", psw.controls.umbracoTemplateVersion.value);
+            searchParams.set("TemplateName", psw.controls.templateName.value);
+            searchParams.set("TemplateVersion", psw.controls.templateVersion.value);
             searchParams.set("Packages", psw.controls.packages.value);
             searchParams.set("UserEmail", psw.controls.userEmail.value);
             searchParams.set("ProjectName", psw.controls.projectName.value);
@@ -521,13 +631,37 @@
             searchParams.set("UseUnattendedInstall", psw.controls.useUnattendedInstall.checked);
             searchParams.set("DatabaseType", psw.controls.databaseType.value);
             searchParams.set("UserPassword", psw.controls.userPassword.value);
-            searchParams.set("UmbracoTemplateVersion", psw.controls.umbracoTemplateVersion.value);
             searchParams.set("UserFriendlyName", psw.controls.userFriendlyName.value);
             searchParams.set("IncludeStarterKit", psw.controls.includeStarterKit.checked);
             searchParams.set("StarterKitPackage", psw.controls.starterKitPackage.value);
             searchParams.set("OnelinerOutput", psw.controls.onelinerOutput.checked);
             var newRelativePathQuery = window.location.pathname + '?' + searchParams.toString();
             history.pushState(null, '', newRelativePathQuery);
+        }
+    },
+    setFieldState: function () {
+        psw.controls.templateVersion.removeAttribute('disabled');
+        psw.controls.starterKitPackage.removeAttribute('disabled');
+        psw.controls.solutionName.removeAttribute('disabled');
+        psw.controls.databaseType.removeAttribute('disabled');
+        psw.controls.userFriendlyName.removeAttribute('disabled');
+        psw.controls.userEmail.removeAttribute('disabled');
+        psw.controls.userPassword.removeAttribute('disabled');
+
+        if (psw.controls.templateName.value === '') {
+            psw.controls.templateVersion.setAttribute('disabled', 'disabled');
+            psw.controls.starterKitPackage.setAttribute('disabled', 'disabled');
+            psw.controls.solutionName.setAttribute('disabled', 'disabled');
+            psw.controls.databaseType.setAttribute('disabled', 'disabled');
+            psw.controls.userFriendlyName.setAttribute('disabled', 'disabled');
+            psw.controls.userEmail.setAttribute('disabled', 'disabled');
+            psw.controls.userPassword.setAttribute('disabled', 'disabled');
+        } else if (psw.controls.templateName.value !== 'Umbraco.Templates') {
+            psw.controls.starterKitPackage.setAttribute('disabled', 'disabled');
+            psw.controls.databaseType.setAttribute('disabled', 'disabled');
+            psw.controls.userFriendlyName.setAttribute('disabled', 'disabled');
+            psw.controls.userEmail.setAttribute('disabled', 'disabled');
+            psw.controls.userPassword.setAttribute('disabled', 'disabled');
         }
     },
     debounce: function (func, wait, immediate) {


### PR DESCRIPTION
Hey Paul,

I've now completed the work on this to allow for the script generation of community templates, as well as umbraco templates. 

The major change is the removal of the "Install an Umbraco Template" checkbox, with a new dropdown field labelled "Template Name". I've also reverted my previous pull request to add the `--force` argument to the template installation command, as well as the .Net 7 or above detection based on the selected Umbraco version. This currently alternates between `-i` and `install`. `--force` is now standard for the install template command, however `install` is no longer applied given there's no firm assumption that the user is running .Net 7 should they happen to install a community template.

The only thing I'm not best pleased with is having a hacky workaround for the `dotnet new <template_name> --force -n "MyProject"....` project create command. There's inconsistency between the short names of templates as they can be different to their package Id. I've had to implement a dictionary which looked up the package Id to resolve the short name. Like so:
```
return new Dictionary<string, string>
{
    { "Umbraco.Community.Templates.UmBootstrap", "umbootstrap" },
    { "UmbCheckout.StarterKit.Stripe", "umbcheckout.starterkit.stripe" }
};
```
I'm sure we may be able to work around this in the future, however for now this is what we've got. If there's a new template which gets added to the marketplace then the packageId is used as a fallback, however a PR may need to be done to add it to this dictionary.

### Screenshots
#### Default
![image](https://github.com/prjseal/Package-Script-Writer/assets/82056925/16fdd3a8-f6ab-4fab-8da5-ffcc95f8aa12)
![image](https://github.com/prjseal/Package-Script-Writer/assets/82056925/187a00c3-f52a-4166-b5cd-213c6dae1f82)

#### Template selection
![image](https://github.com/prjseal/Package-Script-Writer/assets/82056925/91b380f4-6e63-44ce-82d1-da16cff45b8b)

#### Template versions
![image](https://github.com/prjseal/Package-Script-Writer/assets/82056925/0b6a6c1d-c91e-475f-99c6-10037b971dd1)
![image](https://github.com/prjseal/Package-Script-Writer/assets/82056925/f7f45885-00fb-496b-bb2a-98fb8588eed6)
![image](https://github.com/prjseal/Package-Script-Writer/assets/82056925/11255b17-afec-429e-9019-41b5dbc6c57e)

On selecting a community template, the starter kit and unattended install options are disabled and not included within the script:
![image](https://github.com/prjseal/Package-Script-Writer/assets/82056925/0ee41fcd-9892-4c64-aa1d-8cccf7aaab1b)
![image](https://github.com/prjseal/Package-Script-Writer/assets/82056925/d93917fd-1051-48b6-8467-32f8406f7759)

https://github.com/prjseal/Package-Script-Writer/issues/29