### PR TITLE
Alternate `dotnet new -i` and `dotnet new install`

### DIFF
--- a/PSW/PSW/Services/ScriptGeneratorService.cs
+++ b/PSW/PSW/Services/ScriptGeneratorService.cs
@@ -45,6 +45,7 @@ public class ScriptGeneratorService : IScriptGeneratorService
     {
         var outputList = new List<string>();
         var templateName = model.TemplateName;
+        var installCommand = model.TemplateName.Equals(GlobalConstants.TEMPLATE_NAME_UMBRACO, StringComparison.InvariantCultureIgnoreCase) && !(model.TemplateVersion?.StartsWith("9.") == true || model.TemplateVersion?.StartsWith("10.") == true) ? "install" : "-i";
 
         if (!string.IsNullOrEmpty(templateName))
         {
@@ -53,19 +54,19 @@ public class ScriptGeneratorService : IScriptGeneratorService
             {
                 if (!model.OnelinerOutput)
                 {
-                    outputList.Add(templateName.Equals(GlobalConstants.TEMPLATE_NAME_UMBRACO) ? "# Ensure we have the version specific Umbraco templates" : "# Ensure we have the version specific Community templates");
+                    outputList.Add(templateName.Equals(GlobalConstants.TEMPLATE_NAME_UMBRACO, StringComparison.InvariantCultureIgnoreCase) ? "# Ensure we have the version specific Umbraco templates" : "# Ensure we have the version specific Community templates");
                 }
 
-                outputList.Add($"dotnet new -i {templateName}::{model.TemplateVersion} --force");
+                outputList.Add($"dotnet new {installCommand} {templateName}::{model.TemplateVersion} --force");
             }
             else
             {
                 if (!model.OnelinerOutput)
                 {
-                    outputList.Add(templateName.Equals(GlobalConstants.TEMPLATE_NAME_UMBRACO) ? "# Ensure we have the latest Umbraco templates" : "# Ensure we have the latest Community templates");
+                    outputList.Add(templateName.Equals(GlobalConstants.TEMPLATE_NAME_UMBRACO, StringComparison.InvariantCultureIgnoreCase) ? "# Ensure we have the latest Umbraco templates" : "# Ensure we have the latest Community templates");
                 }
 
-                outputList.Add($"dotnet new -i {templateName} --force");
+                outputList.Add($"dotnet new {installCommand} {templateName} --force");
             }
         }
 


### PR DESCRIPTION
Hey Paul,

Following on from our recent discussion on Discord. 

My first PR introduced the ability to alternate between `dotnet new -i` and `dotnet new install` depending on the selected Umbraco template version. Given my second PR introduced some significant changes around templates at the time I thought it was best to revert that addition.

Upon review I can see that we can still achieve a similar desired effect using the current implementation of the code. 

This PR will present:
- `dotnet new install` if the selected template is "Umbraco.Templates" and version 11 or higher
- `dotnet new -i` for all other templates or versions (i.e. Umbraco v9/10 or a community template)