### PR TITLE
Alternate `dotnet new -i` and `dotnet new install` - fix for community templates

### DIFF
--- a/PSW/PSW/Services/ScriptGeneratorService.cs
+++ b/PSW/PSW/Services/ScriptGeneratorService.cs
@@ -45,7 +45,7 @@ public class ScriptGeneratorService : IScriptGeneratorService
     {
         var outputList = new List<string>();
         var templateName = model.TemplateName;
-        var installCommand = model.TemplateName.Equals(GlobalConstants.TEMPLATE_NAME_UMBRACO, StringComparison.InvariantCultureIgnoreCase) && !(model.TemplateVersion?.StartsWith("9.") == true || model.TemplateVersion?.StartsWith("10.") == true) ? "install" : "-i";
+        var installCommand = model.TemplateName.Equals(GlobalConstants.TEMPLATE_NAME_UMBRACO, StringComparison.InvariantCultureIgnoreCase) && (model.TemplateVersion?.StartsWith("9.") == true || model.TemplateVersion?.StartsWith("10.") == true) ? "-i" : "install";
 
         if (!string.IsNullOrEmpty(templateName))
         {


### PR DESCRIPTION
As per: https://github.com/prjseal/Package-Script-Writer/pull/36 

Re-jigged the condition to apply the `dotnet new install` command to community templates as well as Umbraco 11 or above.