### PR TITLE
Update UmbracoMarketplaceResponse.cs

### DIFF
--- a/PSW/PSW/Models/UmbracoMarketplaceResponse.cs
+++ b/PSW/PSW/Models/UmbracoMarketplaceResponse.cs
@@ -25,7 +25,7 @@ public class PagedPackagesPackage
     public Guid Id { get; set; }
     [JsonPropertyName("PackageUrl")]
 #pragma warning disable CA1056 // URI-like properties should not be strings
-    public string Url => $"https://marketplace.umbraco.com/package/{NuGetPackageId}";
+    public string Url => $"https://marketplace.umbraco.com/package/{NuGetPackageId.ToLower()}";
 #pragma warning restore CA1056 // URI-like properties should not be strings
     public bool IsHQ { get; set; }
     public bool IsHQSupported { get; set; }


### PR DESCRIPTION
Hey Paul, this is a bit of a workaround to (hopefully) resolve this issue on Marketplace - https://github.com/umbraco/Umbraco.Marketplace.Issues/issues/81.

Google seems to be disregarding Marketplace's canonical declarations, and instead using the links found on PSW (which makes sense as PSW is a credible source). However, the links from PSW are using the sentence-cased Nuget id in the URL, where Marketplace uses lowercase. This means that a lot of packages are not indexed as Google determines pages have duplicate canonical URLs.

I've tried resolving this with 301s from upper to lower-cased URLs, but in hindsight I think that's still only an on-site optimisation as Google has already found the PSW links, and prefers those.

This PR updates the package URLs to use a lower-cased Nuget id, which should then resolve the duplicate URLs, and everything should end up in Google's index. 

Admittedly it's not an ideal solution (it should be fixable on Marketplace, but all the hints we've given Google - canonical attributes, sitemap, 301s etc don't seem to outweigh PSW's authority), but if you'd kindly merge this change, the world will be an every so slightly better place.
