### PR TITLE
Add OpenAPI annotations to all API controllers

### DIFF
--- a/src/PSW/Controllers/ScriptGeneratorApiController.cs
+++ b/src/PSW/Controllers/ScriptGeneratorApiController.cs
@@ -6,8 +6,12 @@ using PSW.Models;
 
 namespace PSW.Controllers;
 
+/// <summary>
+/// API controller for generating package installation scripts and managing package versions
+/// </summary>
 [ApiController]
 [Route("api/[controller]")]
+[Produces("application/json")]
 public class ScriptGeneratorApiController : ControllerBase
 {
     private readonly IScriptGeneratorService _scriptGeneratorService;
@@ -22,8 +26,17 @@ public class ScriptGeneratorApiController : ControllerBase
         _packageService = packageService;
     }
 
+    /// <summary>
+    /// Generates a script for installing packages based on the provided configuration
+    /// </summary>
+    /// <param name="apiRequest">The request containing package and project configuration details</param>
+    /// <returns>A generated script as a string</returns>
+    /// <response code="200">Returns the generated script</response>
+    /// <response code="400">If the request is invalid</response>
     [Route("generatescript")]
     [HttpPost]
+    [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public ActionResult GenerateScript([FromBody] GeneratorApiRequest apiRequest)
     {
         if (apiRequest.IsEmpty)
@@ -50,8 +63,17 @@ public class ScriptGeneratorApiController : ControllerBase
         return Ok(_scriptGeneratorService.GenerateScript(model));
     }
 
+    /// <summary>
+    /// Retrieves available versions for a specific NuGet package
+    /// </summary>
+    /// <param name="apiRequest">The request containing the package ID</param>
+    /// <returns>A list of available package versions</returns>
+    /// <response code="200">Returns the list of package versions</response>
+    /// <response code="400">If the package ID is invalid</response>
     [Route("getpackageversions")]
     [HttpPost]
+    [ProducesResponseType(typeof(List<string>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public ActionResult GetPackageVersions([FromBody] PackageVersionsApiRequest apiRequest)
     {
         int cacheTime = 60;
@@ -67,16 +89,28 @@ public class ScriptGeneratorApiController : ControllerBase
         return Ok(packageVersions);
     }
 
+    /// <summary>
+    /// Test endpoint to verify API connectivity
+    /// </summary>
+    /// <returns>A greeting message with current timestamp</returns>
+    /// <response code="200">Returns a test message with timestamp</response>
     [Route("test")]
     [HttpGet]
+    [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
     public ActionResult Test()
     {
         var model = "Hello, world!. The time is " + DateTime.Now.ToString();
         return Ok(model);
     }
 
+    /// <summary>
+    /// Clears the application cache for packages and templates
+    /// </summary>
+    /// <returns>A confirmation message with timestamp</returns>
+    /// <response code="200">Returns a confirmation message</response>
     [Route("clearcache")]
     [HttpGet]
+    [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
     public ActionResult ClearCache()
     {
         _memoryCache.Remove("allPackages");

--- a/src/PSW/Models/GeneratorApiRequest.cs
+++ b/src/PSW/Models/GeneratorApiRequest.cs
@@ -1,4 +1,8 @@
 ﻿namespace PSW.Models;
+
+/// <summary>
+/// Request model for generating package installation scripts
+/// </summary>
 public class GeneratorApiRequest
 {
     public bool IsEmpty
@@ -16,22 +20,58 @@ public class GeneratorApiRequest
                 + UserPassword + DatabaseType);
         }
     }
+
+    /// <summary>The name of the template to use</summary>
     public string? TemplateName { get; set; }
+
+    /// <summary>The version of the template</summary>
     public string? TemplateVersion { get; set; }
+
+    /// <summary>Comma-separated list of packages to install</summary>
     public string? Packages { get; set; }
+
+    /// <summary>Whether to create a solution file</summary>
     public bool CreateSolutionFile { get; set; }
+
+    /// <summary>The name for the solution</summary>
     public string? SolutionName { get; set; }
+
+    /// <summary>The name for the project</summary>
     public string? ProjectName { get; set; }
+
+    /// <summary>Database connection string</summary>
     public string? ConnectionString { get; set; }
+
+    /// <summary>User-friendly name for the installation</summary>
     public string? UserFriendlyName { get; set; }
+
+    /// <summary>User email address</summary>
     public string? UserEmail { get; set; }
+
+    /// <summary>User password</summary>
     public string? UserPassword { get; set; }
+
+    /// <summary>Whether to include a starter kit</summary>
     public bool IncludeStarterKit { get; set; }
+
+    /// <summary>Whether to include a Dockerfile</summary>
     public bool IncludeDockerfile { get; set; }
+
+    /// <summary>Whether to include Docker Compose configuration</summary>
     public bool IncludeDockerCompose { get; set; }
+
+    /// <summary>The starter kit package to use</summary>
     public string? StarterKitPackage { get; set; }
+
+    /// <summary>Whether to use unattended installation</summary>
     public bool UseUnattendedInstall { get; set; }
+
+    /// <summary>The type of database to use</summary>
     public string? DatabaseType { get; set; }
+
+    /// <summary>Whether to output as a one-liner script</summary>
     public bool OnelinerOutput { get; set; }
+
+    /// <summary>Whether to remove comments from the generated script</summary>
     public bool RemoveComments { get; set; }
 }

--- a/src/PSW/Models/PacakgeVersionsApiRequest.cs
+++ b/src/PSW/Models/PacakgeVersionsApiRequest.cs
@@ -1,6 +1,10 @@
 ﻿namespace PSW.Models;
 
+/// <summary>
+/// Request model for retrieving package versions
+/// </summary>
 public class PackageVersionsApiRequest
 {
+    /// <summary>The NuGet package ID to retrieve versions for</summary>
     public string PackageId { get; set; }
 }

--- a/src/PSW/PSW.csproj
+++ b/src/PSW/PSW.csproj
@@ -5,8 +5,13 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
 	<LangVersion>13</LangVersion>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
+  </ItemGroup>
 
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
     <Exec Command="dotnet format --severity warn --verbosity diagnostic" />

--- a/src/PSW/Program.cs
+++ b/src/PSW/Program.cs
@@ -7,6 +7,26 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddControllersWithViews()
     .AddRazorOptions(options => options.ViewLocationFormats.Add("/{0}.cshtml"));
 builder.Services.AddHttpClient();
+
+// Add Swagger/OpenAPI support
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(options =>
+{
+    options.SwaggerDoc("v1", new Microsoft.OpenApi.Models.OpenApiInfo
+    {
+        Title = "Package Script Writer API",
+        Version = "v1",
+        Description = "API for generating package installation scripts and managing package versions"
+    });
+
+    // Include XML comments in Swagger documentation
+    var xmlFile = $"{System.Reflection.Assembly.GetExecutingAssembly().GetName().Name}.xml";
+    var xmlPath = Path.Combine(AppContext.BaseDirectory, xmlFile);
+    if (File.Exists(xmlPath))
+    {
+        options.IncludeXmlComments(xmlPath);
+    }
+});
 builder.Services.AddScoped<IScriptGeneratorService, ScriptGeneratorService>();
 builder.Services.AddScoped<IPackageService, MarketplacePackageService>();
 builder.Services.AddScoped<IQueryStringService, QueryStringService>();
@@ -24,6 +44,14 @@ if (!app.Environment.IsDevelopment())
     // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
     app.UseHsts();
 }
+
+// Enable Swagger in all environments
+app.UseSwagger();
+app.UseSwaggerUI(options =>
+{
+    options.SwaggerEndpoint("/swagger/v1/swagger.json", "Package Script Writer API v1");
+    options.RoutePrefix = "api/docs"; // Access Swagger UI at /api/docs
+});
 
 app.UseHttpsRedirection();
 


### PR DESCRIPTION
- Add Swashbuckle.AspNetCore NuGet package for OpenAPI support
- Configure Swagger/OpenAPI in Program.cs with XML documentation
- Add comprehensive OpenAPI annotations to ScriptGeneratorApiController:
  * Document all endpoints with XML summary comments
  * Add ProducesResponseType attributes for proper API documentation
  * Include parameter descriptions and response codes
- Add XML documentation to API request models:
  * GeneratorApiRequest with detailed property descriptions
  * PackageVersionsApiRequest with property descriptions
- Enable XML documentation file generation in project settings
- Configure Swagger UI to be accessible at /api/docs