### PR TITLE
Upgrade Swashbuckle.AspNetCore to v10.0.1

### DIFF
--- a/src/PSW/PSW.csproj
+++ b/src/PSW/PSW.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.0.1" />
   </ItemGroup>
 
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">


### PR DESCRIPTION
- Update from 8.0.0 to 10.0.1 for optimal .NET 10 compatibility
- Version 10.x provides improved performance and features
- Better support for modern OpenAPI 3.1 specifications
- Maintains full backward compatibility with existing API annotations