### PR TITLE
Fix Microsoft.OpenApi.Models namespace error in Swashbuckle 10.x

### DIFF
--- a/src/PSW/PSW.csproj
+++ b/src/PSW/PSW.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.OpenApi" Version="2.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.0.1" />
   </ItemGroup>
 


### PR DESCRIPTION
- Add explicit Microsoft.OpenApi v2.0.0 package reference
- Resolves breaking change in Swashbuckle.AspNetCore 10.x
- The Microsoft.OpenApi.Models namespace is no longer automatically available
- This fixes the build error: CS0234 'Models' does not exist in namespace 'Microsoft.OpenApi'

Swashbuckle 10.x upgraded to Microsoft.OpenApi 2.x but doesn't automatically expose the namespace, requiring an explicit package reference.