### PR TITLE
Fix package downgrade error: Update Microsoft.OpenApi to 2.3.0

### DIFF
--- a/src/PSW/PSW.csproj
+++ b/src/PSW/PSW.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.OpenApi" Version="2.0.0" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.3.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.0.1" />
   </ItemGroup>
 


### PR DESCRIPTION
- Update Microsoft.OpenApi from 2.0.0 to 2.3.0
- Resolves NU1605 package downgrade error
- Swashbuckle.AspNetCore 10.0.1 requires Microsoft.OpenApi >= 2.3.0
- This prevents the build failure caused by version mismatch

The previous version (2.0.0) caused a downgrade error because Swashbuckle 10.0.1 transitively depends on Microsoft.OpenApi 2.3.0 or higher.