### PR TITLE
Add Microsoft.OpenApi.Models using statement to Program.cs

### DIFF
--- a/src/PSW/Program.cs
+++ b/src/PSW/Program.cs
@@ -1,3 +1,4 @@
+using Microsoft.OpenApi.Models;
 using PSW.Configuration;
 using PSW.Middleware;
 
@@ -12,7 +13,7 @@ builder.Services.AddHttpClient();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {
-    options.SwaggerDoc("v1", new Microsoft.OpenApi.Models.OpenApiInfo
+    options.SwaggerDoc("v1", new OpenApiInfo
     {
         Title = "Package Script Writer API",
         Version = "v1",


### PR DESCRIPTION
- Add using Microsoft.OpenApi.Models at the top of Program.cs
- Simplify OpenApiInfo instantiation by removing fully qualified name
- Resolves CS0234 build error: 'Models' namespace not found
- Makes code cleaner and more maintainable

The Microsoft.OpenApi.Models namespace needs to be explicitly imported when using types like OpenApiInfo with Swashbuckle 10.x and Microsoft.OpenApi 2.3.0.