### PR TITLE
Remove explicit Microsoft.OpenApi package reference

### DIFF
--- a/src/PSW/PSW.csproj
+++ b/src/PSW/PSW.csproj
@@ -10,7 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.OpenApi" Version="2.3.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.0.1" />
   </ItemGroup>
 


### PR DESCRIPTION
- Remove Microsoft.OpenApi 2.3.0 explicit package reference
- Swashbuckle.AspNetCore 10.0.1 includes Microsoft.OpenApi as a transitive dependency
- This should resolve the namespace resolution issues
- The Microsoft.OpenApi.Models namespace will be available through Swashbuckle's dependencies

The explicit package reference was causing conflicts. Swashbuckle handles its own dependencies and should provide the necessary OpenAPI types.