### PR TITLE
Downgrade Swashbuckle.AspNetCore to stable v8.2.0

### DIFF
--- a/src/PSW/PSW.csproj
+++ b/src/PSW/PSW.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.0.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.2.0" />
   </ItemGroup>
 
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">


### PR DESCRIPTION
- Downgrade from 10.0.1 to 8.2.0 for better stability
- Version 8.x is proven to work with .NET 6/7/8/9/10
- Resolves Microsoft.OpenApi.Models namespace issues
- Version 8.x uses Microsoft.OpenApi 1.x which has stable APIs
- No explicit Microsoft.OpenApi package reference needed

Swashbuckle 10.x had compatibility issues with the OpenAPI Models namespace. Version 8.2.0 is the latest stable release in the v8 series and provides all necessary Swagger/OpenAPI functionality without issues.