### PR TITLE
Restore working Swashbuckle configuration from commit dfe0580

### DIFF
--- a/src/PSW/PSW.csproj
+++ b/src/PSW/PSW.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.2.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.0.0" />
   </ItemGroup>
 
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">

--- a/src/PSW/Program.cs
+++ b/src/PSW/Program.cs
@@ -1,4 +1,3 @@
-using Microsoft.OpenApi.Models;
 using PSW.Configuration;
 using PSW.Middleware;
 
@@ -13,7 +12,7 @@ builder.Services.AddHttpClient();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {
-    options.SwaggerDoc("v1", new OpenApiInfo
+    options.SwaggerDoc("v1", new Microsoft.OpenApi.Models.OpenApiInfo
     {
         Title = "Package Script Writer API",
         Version = "v1",


### PR DESCRIPTION
- Use Swashbuckle.AspNetCore 8.0.0 (proven to work)
- Remove 'using Microsoft.OpenApi.Models' statement
- Use fully qualified namespace: Microsoft.OpenApi.Models.OpenApiInfo
- This was the working state from commit dfe0580

This configuration was previously tested and working successfully.