### PR TITLE
Fix build error: Remove assignment to read-only IsEmpty property

### DIFF
--- a/src/PSW.IntegrationTests/ScriptGeneratorApiTests.cs
+++ b/src/PSW.IntegrationTests/ScriptGeneratorApiTests.cs
@@ -77,11 +77,8 @@ public class ScriptGeneratorApiTests : IClassFixture<CustomWebApplicationFactory
     [Fact]
     public async Task GenerateScript_WithEmptyRequest_ReturnsScriptWithDefaults()
     {
-        // Arrange
-        var request = new GeneratorApiRequest
-        {
-            IsEmpty = true
-        };
+        // Arrange - Create an empty request (all default values)
+        var request = new GeneratorApiRequest();
 
         // Act
         var response = await _client.PostAsJsonAsync("/api/ScriptGeneratorApi/generatescript", request);


### PR DESCRIPTION
The IsEmpty property in GeneratorApiRequest is a computed read-only property. Changed the test to create an empty request object with default values instead of trying to set IsEmpty directly.

This fixes compilation error:
CS0200: Property or indexer 'GeneratorApiRequest.IsEmpty' cannot be assigned to -- it is read only