### PR TITLE
feat: improve package search with LINQ-based filtering

### DIFF
--- a/src/PackageCliTool/Validation/InputValidator.cs
+++ b/src/PackageCliTool/Validation/InputValidator.cs
@@ -154,6 +154,26 @@ public static class InputValidator
     }
 
     /// <summary>
+    /// Checks if a string is a valid NuGet package ID
+    /// </summary>
+    /// <param name="packageId">The package ID to validate</param>
+    /// <returns>True if the package ID is valid, false otherwise</returns>
+    public static bool IsValidNuGetPackageId(string packageId)
+    {
+        if (string.IsNullOrWhiteSpace(packageId))
+        {
+            return false;
+        }
+
+        // NuGet package IDs should follow these rules:
+        // - Only contain letters, numbers, dots, hyphens, and underscores
+        // - Must not start or end with a dot
+        // - Must not contain consecutive dots
+        var packageRegex = new Regex(@"^[A-Za-z0-9_\-]+([\.][A-Za-z0-9_\-]+)*$");
+        return packageRegex.IsMatch(packageId);
+    }
+
+    /// <summary>
     /// Validates a version string
     /// </summary>
     public static void ValidateVersion(string version)


### PR DESCRIPTION
Replace autocomplete with search term input and implement comprehensive package searching:

- Remove autocomplete from package search in CLI tool
- Add text input for search terms
- Implement LINQ filtering across package Title, PackageId, and Author fields (case-insensitive)
- Display matching results in paginated select prompt (10 per page)
- Add NuGet package ID validation helper method
- When no matches found but search term is valid package ID, prompt user to add it anyway
- Improve user experience with clear feedback and better package selection workflow

This enhances package discovery and allows users to add packages not in the marketplace.