### PR TITLE
feat: add template selection with version selection to CLI tool

### DIFF
--- a/src/PackageCliTool/UI/InteractivePrompts.cs
+++ b/src/PackageCliTool/UI/InteractivePrompts.cs
@@ -11,10 +11,10 @@ public static class InteractivePrompts
     /// <summary>
     /// Prompts user for all script configuration options
     /// </summary>
-    public static ScriptModel PromptForScriptConfiguration(Dictionary<string, string> packageVersions)
+    public static ScriptModel PromptForScriptConfiguration(Dictionary<string, string> packageVersions, string? templateName = null, string? templateVersion = null)
     {
         AnsiConsole.WriteLine();
-        AnsiConsole.MarkupLine("[bold blue]Step 4:[/] Configure Project Options\n");
+        AnsiConsole.MarkupLine("[bold blue]Step 7:[/] Configure Project Options\n");
 
         // Build packages string with proper format handling
         var packageParts = new List<string>();
@@ -41,30 +41,13 @@ public static class InteractivePrompts
         // Create a script model and populate it with user inputs
         var model = new ScriptModel
         {
-            TemplateName = "Umbraco.Templates",
+            TemplateName = templateName ?? "Umbraco.Templates",
+            TemplateVersion = templateVersion ?? "",
             Packages = packagesString
         };
 
         // Template and Project Configuration
         AnsiConsole.MarkupLine("[bold yellow]Template & Project Settings[/]\n");
-
-        model.TemplateVersion = AnsiConsole.Prompt(
-            new SelectionPrompt<string>()
-                .Title("Select [green]Umbraco template version[/]:")
-                .AddChoices(new[] { "Latest Stable", "Latest LTS", "14.3.0", "14.2.0", "14.1.0", "14.0.0", "13.5.2", "13.4.0", "13.3.0", "Custom..." }));
-
-        if (model.TemplateVersion == "Custom...")
-        {
-            model.TemplateVersion = AnsiConsole.Ask<string>("Enter [green]custom version[/]:");
-        }
-        else if (model.TemplateVersion == "Latest Stable")
-        {
-            model.TemplateVersion = "";
-        }
-        else if (model.TemplateVersion == "Latest LTS")
-        {
-            model.TemplateVersion = "LTS";
-        }
 
         model.ProjectName = AnsiConsole.Ask<string>("Enter [green]project name[/]:", "MyProject");
 

--- a/src/PackageCliTool/Workflows/InteractiveModeWorkflow.cs
+++ b/src/PackageCliTool/Workflows/InteractiveModeWorkflow.cs
@@ -131,27 +131,35 @@ public class InteractiveModeWorkflow
         // Step 2: For each package, select version
         var packageVersions = await _packageSelector.SelectVersionsForPackagesAsync(selectedPackages);
 
-        // Step 3: Display final selection
+        // Step 3: Select template
+        AnsiConsole.WriteLine();
+        AnsiConsole.MarkupLine("[bold blue]Step 3:[/] Select Template\n");
+        var templateName = await _packageSelector.SelectTemplateAsync();
+
+        // Step 4: Select template version
+        var templateVersion = await _packageSelector.SelectTemplateVersionAsync(templateName);
+
+        // Step 5: Display final selection
         ConfigurationDisplay.DisplayFinalSelection(packageVersions);
 
-        // Step 4: Optional - Generate script
+        // Step 6: Optional - Generate script
         var shouldGenerate2 = AnsiConsole.Confirm("Would you like to generate a complete installation script?");
 
         if (shouldGenerate2)
         {
-            await GenerateAndDisplayScriptAsync(packageVersions);
+            await GenerateAndDisplayScriptAsync(packageVersions, templateName, templateVersion);
         }
     }
 
     /// <summary>
     /// Generates a complete installation script using the API
     /// </summary>
-    private async Task GenerateAndDisplayScriptAsync(Dictionary<string, string> packageVersions)
+    private async Task GenerateAndDisplayScriptAsync(Dictionary<string, string> packageVersions, string? templateName = null, string? templateVersion = null)
     {
         _logger?.LogInformation("Generating complete installation script");
 
         // Prompt for configuration
-        var model = InteractivePrompts.PromptForScriptConfiguration(packageVersions);
+        var model = InteractivePrompts.PromptForScriptConfiguration(packageVersions, templateName, templateVersion);
 
         // Display configuration summary
         ConfigurationDisplay.DisplayConfigurationSummary(model, packageVersions);


### PR DESCRIPTION
Added interactive template selection with version selection similar to package selection:
- Created GetTemplatesAsync() method with hard-coded template values:
  - Umbraco.Templates
  - Umbraco.Community.Templates.Clean
  - Umbraco.Community.Templates.UmBootstrap
- Added SelectTemplateAsync() for single select template selection with pagination (10 per page)
- Added SelectTemplateVersionAsync() to select template version using API
- Updated InteractiveModeWorkflow to include template selection steps
- Modified InteractivePrompts to accept template name and version parameters
- Template selection follows the same pattern as package selection

The template selection occurs after package version selection in the interactive flow.