### PR TITLE
feat: add clipboard copy, start over, back navigation, and starter kit version selection

### DIFF
--- a/src/PackageCliTool/PackageCliTool.csproj
+++ b/src/PackageCliTool/PackageCliTool.csproj
@@ -56,6 +56,7 @@
     <PackageReference Include="Polly" Version="8.5.0" />
     <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
     <PackageReference Include="YamlDotNet" Version="16.2.1" />
+    <PackageReference Include="TextCopy" Version="6.2.1" />
 
     <!-- Source Link Support -->
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />

--- a/src/PackageCliTool/Services/ClipboardHelper.cs
+++ b/src/PackageCliTool/Services/ClipboardHelper.cs
@@ -1,0 +1,30 @@
+using Microsoft.Extensions.Logging;
+using Spectre.Console;
+using TextCopy;
+
+namespace PackageCliTool.Services;
+
+/// <summary>
+/// Helper class for clipboard operations
+/// </summary>
+public static class ClipboardHelper
+{
+    /// <summary>
+    /// Copies text to clipboard and displays a success message
+    /// </summary>
+    public static async Task CopyToClipboardAsync(string text, ILogger? logger = null)
+    {
+        try
+        {
+            await ClipboardService.SetTextAsync(text);
+            AnsiConsole.MarkupLine("[green]✓ Script copied to clipboard successfully![/]");
+            logger?.LogInformation("Script copied to clipboard");
+        }
+        catch (Exception ex)
+        {
+            logger?.LogWarning(ex, "Failed to copy script to clipboard");
+            AnsiConsole.MarkupLine("[yellow]⚠ Failed to copy to clipboard: {0}[/]", ex.Message);
+            AnsiConsole.MarkupLine("[dim]You can manually copy the script from the output above.[/]");
+        }
+    }
+}

--- a/src/PackageCliTool/Workflows/CliModeWorkflow.cs
+++ b/src/PackageCliTool/Workflows/CliModeWorkflow.cs
@@ -281,5 +281,24 @@ public class CliModeWorkflow
         {
             AnsiConsole.MarkupLine("[yellow]Please re-run the tool with different options to edit the script.[/]");
         }
+        else if (action == "Copy to clipboard")
+        {
+            await ClipboardHelper.CopyToClipboardAsync(script, _logger);
+
+            // Ask if they want to do something else with the script
+            var continueAction = AnsiConsole.Confirm("\nWould you like to do something else with this script?", false);
+            if (continueAction)
+            {
+                await HandleInteractiveScriptActionAsync(script);
+            }
+        }
+        else if (action == "← Back")
+        {
+            AnsiConsole.MarkupLine("[yellow]Cannot go back in CLI mode. Please re-run the tool with different options.[/]");
+        }
+        else if (action == "Start over")
+        {
+            AnsiConsole.MarkupLine("[yellow]To start over, please re-run the tool with different command-line options.[/]");
+        }
     }
 }


### PR DESCRIPTION
Added three major enhancements to the CLI tool:

1. Script Action Menu Enhancements:
   - Added 'Copy to clipboard' option to save scripts to clipboard
   - Added 'Start over' option to restart the entire workflow
   - Added '← Back' option for navigation to previous step
   - Reordered menu items for better UX (Run, Edit, Copy, Back, Start over)

2. Starter Kit Version Selection:
   - Removed hardcoded starter kit versions
   - Now dynamically fetches available versions from API
   - Users select starter kit name first, then choose version
   - Matches the same UX pattern as regular package version selection
   - Supports "Latest Stable" option

3. Clipboard Support:
   - Added TextCopy NuGet package (v6.2.1) for cross-platform clipboard
   - Created ClipboardHelper utility class for clipboard operations
   - Graceful error handling with user-friendly messages

Technical Changes:
   - Made PromptForScriptConfiguration async to support API calls
   - Updated InteractiveModeWorkflow and CliModeWorkflow to handle new actions
   - Added navigation context to support '← Back' functionality
   - Enhanced error handling for version fetching failures

Files Modified:
   - PackageCliTool.csproj: Added TextCopy dependency
   - UI/InteractivePrompts.cs: Enhanced script action menu, async starter kit selection
   - Workflows/InteractiveModeWorkflow.cs: Handle new actions, support back navigation
   - Workflows/CliModeWorkflow.cs: Handle new actions with CLI-appropriate messages
   - Services/ClipboardHelper.cs: New utility for clipboard operations