### PR TITLE
feat: replace back navigation with Ctrl+C restart functionality

### DIFF
--- a/src/PackageCliTool/Program.cs
+++ b/src/PackageCliTool/Program.cs
@@ -88,12 +88,29 @@ class Program
             }
             else
             {
-                var interactiveWorkflow = new InteractiveModeWorkflow(
-                    apiClient,
-                    packageSelector,
-                    scriptExecutor,
-                    logger);
-                await interactiveWorkflow.RunAsync();
+                // Interactive mode with Ctrl+C restart support
+                var keepRunning = true;
+                while (keepRunning)
+                {
+                    try
+                    {
+                        var interactiveWorkflow = new InteractiveModeWorkflow(
+                            apiClient,
+                            packageSelector,
+                            scriptExecutor,
+                            logger);
+                        await interactiveWorkflow.RunAsync();
+                        keepRunning = false; // Exit loop on normal completion
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        // User pressed Ctrl+C - restart the workflow
+                        logger?.LogInformation("User pressed Ctrl+C, restarting interactive mode");
+                        AnsiConsole.Clear();
+                        AnsiConsole.MarkupLine("\n[yellow]↻ Restarting...[/]\n");
+                        await Task.Delay(500); // Brief pause before restart
+                    }
+                }
             }
 
             // Display completion message

--- a/src/PackageCliTool/UI/ConsoleDisplay.cs
+++ b/src/PackageCliTool/UI/ConsoleDisplay.cs
@@ -21,6 +21,7 @@ public static class ConsoleDisplay
 
         AnsiConsole.MarkupLine("[dim]Package Script Writer - Interactive CLI[/]");
         AnsiConsole.MarkupLine("[dim]By Paul Seal[/]");
+        AnsiConsole.MarkupLine("[dim]Press Ctrl+C at any time to start over[/]");
         AnsiConsole.WriteLine();
     }
 

--- a/src/PackageCliTool/UI/InteractivePrompts.cs
+++ b/src/PackageCliTool/UI/InteractivePrompts.cs
@@ -197,8 +197,8 @@ public static class InteractivePrompts
     {
         return AnsiConsole.Prompt(
             new SelectionPrompt<string>()
-                .Title("\nWhat would you like to do with this script?")
-                .AddChoices(new[] { "Run", "Edit", "Copy to clipboard", "← Back", "Start over" }));
+                .Title("\nWhat would you like to do with this script?\n[dim](Press Ctrl+C at any time to start over)[/]")
+                .AddChoices(new[] { "Run", "Edit", "Copy to clipboard", "Start over" }));
     }
 
     /// <summary>

--- a/src/PackageCliTool/Workflows/CliModeWorkflow.cs
+++ b/src/PackageCliTool/Workflows/CliModeWorkflow.cs
@@ -292,10 +292,6 @@ public class CliModeWorkflow
                 await HandleInteractiveScriptActionAsync(script);
             }
         }
-        else if (action == "← Back")
-        {
-            AnsiConsole.MarkupLine("[yellow]Cannot go back in CLI mode. Please re-run the tool with different options.[/]");
-        }
         else if (action == "Start over")
         {
             AnsiConsole.MarkupLine("[yellow]To start over, please re-run the tool with different command-line options.[/]");

--- a/src/PackageCliTool/Workflows/InteractiveModeWorkflow.cs
+++ b/src/PackageCliTool/Workflows/InteractiveModeWorkflow.cs
@@ -247,21 +247,6 @@ public class InteractiveModeWorkflow
                 await HandleScriptSaveAndRunAsync(script, packageVersions, templateName, templateVersion);
             }
         }
-        else if (action == "← Back")
-        {
-            // Go back to regenerate the script with different configuration
-            if (packageVersions != null)
-            {
-                AnsiConsole.MarkupLine("\n[blue]Going back to reconfigure the script...[/]\n");
-                _logger?.LogInformation("User chose to go back and reconfigure");
-                await GenerateAndDisplayScriptAsync(packageVersions, templateName, templateVersion);
-            }
-            else
-            {
-                AnsiConsole.MarkupLine("[yellow]Cannot go back from here. Use 'Start over' instead.[/]");
-                await HandleScriptSaveAndRunAsync(script, packageVersions, templateName, templateVersion);
-            }
-        }
         else if (action == "Start over")
         {
             AnsiConsole.MarkupLine("\n[blue]Starting over...[/]\n");


### PR DESCRIPTION
Removed the '← Back' menu option and implemented Ctrl+C handling to restart the interactive workflow from the beginning.

Changes:
1. Removed '← Back' option from script action menu
2. Removed all '← Back' handling code from workflows
3. Implemented Ctrl+C (OperationCanceledException) handling in Program.cs
   - Catches Ctrl+C in interactive mode
   - Clears screen and restarts workflow from beginning
   - Shows "↻ Restarting..." message
4. Added Ctrl+C instructions to welcome banner
5. Added Ctrl+C hint to script action menu title

Technical Notes:
- Spectre.Console doesn't support ESC key detection in prompts
- Ctrl+C is the standard terminal convention for cancellation/restart
- When Ctrl+C is pressed, the workflow restarts from the very beginning
- Works only in interactive mode (not CLI mode with arguments)

Files Modified:
- Program.cs: Added Ctrl+C restart loop for interactive mode
- UI/ConsoleDisplay.cs: Added Ctrl+C hint to welcome banner
- UI/InteractivePrompts.cs: Removed '← Back', added Ctrl+C hint to menu
- Workflows/InteractiveModeWorkflow.cs: Removed '← Back' handling
- Workflows/CliModeWorkflow.cs: Removed '← Back' handling