### PR TITLE
feat: add 'Save as template' option after script generation

### DIFF
--- a/src/PackageCliTool/UI/InteractivePrompts.cs
+++ b/src/PackageCliTool/UI/InteractivePrompts.cs
@@ -198,7 +198,7 @@ public static class InteractivePrompts
         return AnsiConsole.Prompt(
             new SelectionPrompt<string>()
                 .Title("\nWhat would you like to do with this script?\n[dim](Press Ctrl+C at any time to start over)[/]")
-                .AddChoices(new[] { "Run", "Edit", "Copy to clipboard", "Start over" }));
+                .AddChoices(new[] { "Run", "Edit", "Copy to clipboard", "Save as template", "Start over" }));
     }
 
     /// <summary>


### PR DESCRIPTION
Added the ability to save script configurations as reusable templates directly from the interactive workflow.

Changes:
1. Added "Save as template" option to script action menu
   - Menu now shows: Run, Edit, Copy to clipboard, Save as template, Start over
   - Option appears after script is generated

2. Created FromScriptModel method in TemplateService
   - Converts ScriptModel + packageVersions to Template
   - Mirrors FromCommandLineOptions but works with interactive mode data
   - Includes ConvertPackageVersionsToConfigs helper method

3. Implemented SaveAsTemplateAsync in InteractiveModeWorkflow
   - Prompts for template name, description, and tags
   - Uses the same interactive prompts as CLI template save command
   - Checks for existing templates and offers to overwrite
   - Shows success message with instructions to load template
   - Integrated with TemplateService for template management

4. Updated HandleScriptSaveAndRunAsync signature
   - Now accepts ScriptModel and packageVersions
   - Enables template creation from generated scripts
   - Maintains all existing functionality

Benefits:
- Users can quickly save frequently-used configurations
- No need to remember CLI flags for template save
- Seamless integration with existing template system
- Templates can be reused with: psw template load <name>

Files Modified:
- Services/TemplateService.cs: Added FromScriptModel and helper methods
- UI/InteractivePrompts.cs: Added "Save as template" to menu
- Workflows/InteractiveModeWorkflow.cs: Added template save workflow