### PR TITLE
feat: preserve values when editing script configuration

### DIFF
--- a/src/PackageCliTool/Workflows/InteractiveModeWorkflow.cs
+++ b/src/PackageCliTool/Workflows/InteractiveModeWorkflow.cs
@@ -156,12 +156,12 @@ public class InteractiveModeWorkflow
     /// <summary>
     /// Generates a complete installation script using the API
     /// </summary>
-    private async Task GenerateAndDisplayScriptAsync(Dictionary<string, string> packageVersions, string? templateName = null, string? templateVersion = null)
+    private async Task GenerateAndDisplayScriptAsync(Dictionary<string, string> packageVersions, string? templateName = null, string? templateVersion = null, ScriptModel? existingModel = null)
     {
         _logger?.LogInformation("Generating complete installation script");
 
-        // Prompt for configuration
-        var model = await InteractivePrompts.PromptForScriptConfigurationAsync(packageVersions, _apiClient, _logger, templateName, templateVersion);
+        // Prompt for configuration (with existing model values as defaults if editing)
+        var model = await InteractivePrompts.PromptForScriptConfigurationAsync(packageVersions, _apiClient, _logger, templateName, templateVersion, existingModel);
 
         // Display configuration summary
         ConfigurationDisplay.DisplayConfigurationSummary(model, packageVersions);
@@ -235,8 +235,18 @@ public class InteractiveModeWorkflow
         }
         else if (action == "Edit")
         {
-            AnsiConsole.MarkupLine("\n[blue]Let's configure a custom script...[/]\n");
-            await RunCustomFlowAsync();
+            AnsiConsole.MarkupLine("\n[blue]Editing script configuration...[/]\n");
+
+            if (scriptModel != null && packageVersions != null)
+            {
+                // Edit with existing values as defaults
+                await GenerateAndDisplayScriptAsync(packageVersions, templateName, templateVersion, scriptModel);
+            }
+            else
+            {
+                // Fallback to starting from scratch
+                await RunCustomFlowAsync();
+            }
         }
         else if (action == "Copy to clipboard")
         {


### PR DESCRIPTION
When choosing "Edit" after generating a script, all prompts now use the current script configuration values as defaults instead of hardcoded defaults.

Changes:
1. Updated PromptForScriptConfigurationAsync signature
   - Added optional existingModel parameter
   - All prompts now use existingModel values as defaults when available
   - Falls back to original defaults if no existing model provided

2. Updated all configuration prompts to use existing values:
   - Project name and solution settings
   - Starter kit options
   - Docker configuration
   - Unattended install settings (database, admin credentials)
   - Output format options

3. Modified Edit action in InteractiveModeWorkflow
   - Changed message from "Let's configure a custom script" to "Editing script configuration"
   - Passes existing scriptModel to GenerateAndDisplayScriptAsync
   - Falls back to RunCustomFlowAsync if no existing model

4. Updated GenerateAndDisplayScriptAsync signature
   - Added optional existingModel parameter
   - Passes existing model to PromptForScriptConfigurationAsync

Benefits:
- Easier to make small tweaks to generated scripts
- No need to re-enter all values when editing
- Better user experience - shows what you had before
- Consistent with "edit" semantics in other tools

Example:
- Generate script with ProjectName="MyCustomProject"
- Choose "Edit"
- ProjectName prompt now shows "MyCustomProject" as default
- Just press Enter to keep it, or type new value to change

Files Modified:
- UI/InteractivePrompts.cs: Accept and use existing model as defaults
- Workflows/InteractiveModeWorkflow.cs: Pass existing model when editing