### PR TITLE
fix: enable saving default script as template

### DIFF
--- a/src/PackageCliTool/Workflows/InteractiveModeWorkflow.cs
+++ b/src/PackageCliTool/Workflows/InteractiveModeWorkflow.cs
@@ -103,7 +103,9 @@ public class InteractiveModeWorkflow
         ConsoleDisplay.DisplayGeneratedScript(script, "Generated Default Installation Script");
 
         // Option to save and run the script
-        await HandleScriptSaveAndRunAsync(script);
+        // Create empty packageVersions dict since default script has no packages
+        var packageVersions = new Dictionary<string, string>();
+        await HandleScriptSaveAndRunAsync(script, model, packageVersions);
     }
 
     /// <summary>


### PR DESCRIPTION
Fixed issue where choosing "Save as template" after generating a default script would show error "Cannot save template - script configuration not available."

Problem:
- GenerateDefaultScriptAsync() called HandleScriptSaveAndRunAsync() with only the script parameter
- This meant scriptModel and packageVersions were null
- SaveAsTemplateAsync checks if these are null and returns error

Solution:
- Pass the model to HandleScriptSaveAndRunAsync()
- Create empty packageVersions dictionary (default script has no packages)
- Now template can be saved with all default script configuration

Changes:
- Updated GenerateDefaultScriptAsync() to pass model and empty packageVersions dict
- Added explanatory comment about why packageVersions is empty

Now users can:
- Generate default script
- Choose "Save as template"
- Template is saved with all default configuration values
- Can reload with: psw template load <name>

Files Modified:
- Workflows/InteractiveModeWorkflow.cs: Pass model and packageVersions when handling default script