### PR TITLE
Fix script generation hang by using synchronous Spectre.Console methods

### DIFF
--- a/src/PackageCliTool/Workflows/CliModeWorkflow.cs
+++ b/src/PackageCliTool/Workflows/CliModeWorkflow.cs
@@ -82,10 +82,10 @@ public class CliModeWorkflow
             RemoveComments = false
         };
 
-        var script = await AnsiConsole.Status()
+        var script = AnsiConsole.Status()
             .Spinner(Spinner.Known.Star)
             .SpinnerStyle(Style.Parse("green"))
-            .StartAsync("Generating default installation script...", async ctx =>
+            .Start("Generating default installation script...", ctx =>
             {
                 return _scriptGeneratorService.GenerateScript(model.ToViewModel());
                 //return await _apiClient.GenerateScriptAsync(model);
@@ -198,10 +198,10 @@ public class CliModeWorkflow
         // Generate the script
         _logger?.LogInformation("Generating installation script via API");
 
-        var script = await AnsiConsole.Status()
+        var script = AnsiConsole.Status()
             .Spinner(Spinner.Known.Star)
             .SpinnerStyle(Style.Parse("green"))
-            .StartAsync("Generating installation script...", async ctx =>
+            .Start("Generating installation script...", ctx =>
             {
                 return _scriptGeneratorService.GenerateScript(model.ToViewModel());
                 //return await _apiClient.GenerateScriptAsync(model);

--- a/src/PackageCliTool/Workflows/InteractiveModeWorkflow.cs
+++ b/src/PackageCliTool/Workflows/InteractiveModeWorkflow.cs
@@ -95,10 +95,10 @@ public class InteractiveModeWorkflow
             RemoveComments = false
         };
 
-        var script = await AnsiConsole.Status()
+        var script = AnsiConsole.Status()
             .Spinner(Spinner.Known.Star)
             .SpinnerStyle(Style.Parse("green"))
-            .StartAsync("Generating default installation script...", async ctx =>
+            .Start("Generating default installation script...", ctx =>
             {
                 return _scriptGeneratorService.GenerateScript(model.ToViewModel());
                 //return await _apiClient.GenerateScriptAsync(model);
@@ -184,10 +184,10 @@ public class InteractiveModeWorkflow
 
         _logger?.LogInformation("Generating installation script via API");
 
-        var script = await AnsiConsole.Status()
+        var script = AnsiConsole.Status()
             .Spinner(Spinner.Known.Star)
             .SpinnerStyle(Style.Parse("green"))
-            .StartAsync("Generating installation script...", async ctx =>
+            .Start("Generating installation script...", ctx =>
             {
                 return _scriptGeneratorService.GenerateScript(model.ToViewModel());
                 //return await _apiClient.GenerateScriptAsync(model);


### PR DESCRIPTION
The script generation was hanging because StartAsync() was being used with a
synchronous GenerateScript() method, causing an async/sync mismatch. Changed
to use the synchronous Start() method instead in both workflow files.

Changes:
- InteractiveModeWorkflow.cs: Changed StartAsync to Start (2 locations)
- CliModeWorkflow.cs: Changed StartAsync to Start (2 locations)