### PR TITLE
Move package version logic from API to CLI tool

### DIFF
--- a/src/PackageCliTool/Program.cs
+++ b/src/PackageCliTool/Program.cs
@@ -1,4 +1,5 @@
 
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -71,6 +72,8 @@ class Program
             var serviceProvider = services.BuildServiceProvider();
 
             var scriptGeneratorService = serviceProvider.GetRequiredService<IScriptGeneratorService>();
+            var packageService = serviceProvider.GetRequiredService<IPackageService>();
+            var memoryCache = serviceProvider.GetRequiredService<IMemoryCache>();
 
             // Handle help flag
             if (options.ShowHelp)
@@ -104,7 +107,7 @@ class Program
 
             // Initialize services that depend on configuration
             var apiClient = new ApiClient(ApiConfiguration.ApiBaseUrl, logger, cacheService);
-            var packageSelector = new PackageSelector(apiClient, logger);
+            var packageSelector = new PackageSelector(apiClient, packageService, memoryCache, logger);
             var scriptExecutor = new ScriptExecutor(logger);
             var templateService = new TemplateService(logger: logger);
             var historyService = new HistoryService(logger: logger);

--- a/src/PackageCliTool/Workflows/InteractiveModeWorkflow.cs
+++ b/src/PackageCliTool/Workflows/InteractiveModeWorkflow.cs
@@ -139,7 +139,7 @@ public class InteractiveModeWorkflow
         }
 
         // Step 2: For each package, select version
-        var packageVersions = await _packageSelector.SelectVersionsForPackagesAsync(selectedPackages);
+        var packageVersions = _packageSelector.SelectVersionsForPackages(selectedPackages);
 
         // Step 3: Select template
         AnsiConsole.WriteLine();
@@ -147,7 +147,7 @@ public class InteractiveModeWorkflow
         var templateName = await _packageSelector.SelectTemplateAsync();
 
         // Step 4: Select template version
-        var templateVersion = await _packageSelector.SelectTemplateVersionAsync(templateName);
+        var templateVersion = _packageSelector.SelectTemplateVersion(templateName);
 
         // Step 5: Display final selection
         ConfigurationDisplay.DisplayFinalSelection(packageVersions);


### PR DESCRIPTION
- Add IPackageService and IMemoryCache dependencies to PackageSelector
- Implement GetPackageVersions method using MarketplacePackageService directly
- Add caching using IMemoryCache.GetOrCreate pattern (same as API)
- Convert SelectVersionsForPackagesAsync to synchronous SelectVersionsForPackages
- Convert SelectTemplateVersionAsync to synchronous SelectTemplateVersion
- Update Spectre Console calls from StartAsync to Start
- Update Program.cs to inject IPackageService and IMemoryCache
- Update InteractiveModeWorkflow to call synchronous methods

The CLI now fetches package versions directly from NuGet API via the shared
MarketplacePackageService instead of making HTTP calls to the PSW API endpoint.
This reduces API dependencies and improves performance with local caching.