### PR TITLE
Remove all remaining API calls from CLI tool

### DIFF
--- a/src/PackageCliTool/Program.cs
+++ b/src/PackageCliTool/Program.cs
@@ -115,13 +115,13 @@ class Program
             // Check if this is a history command
             if (options.IsHistoryCommand())
             {
-                var historyWorkflow = new HistoryWorkflow(historyService, apiClient, scriptExecutor, logger);
+                var historyWorkflow = new HistoryWorkflow(historyService, scriptExecutor, scriptGeneratorService, logger);
                 await historyWorkflow.RunAsync(options);
             }
             // Check if this is a template command
             else if (options.IsTemplateCommand())
             {
-                var templateWorkflow = new TemplateWorkflow(templateService, apiClient, scriptExecutor, logger);
+                var templateWorkflow = new TemplateWorkflow(templateService, scriptExecutor, scriptGeneratorService, logger);
                 await templateWorkflow.RunAsync(options);
             }
             // Determine if we should use CLI mode or interactive mode

--- a/src/PackageCliTool/Workflows/HistoryWorkflow.cs
+++ b/src/PackageCliTool/Workflows/HistoryWorkflow.cs
@@ -2,6 +2,8 @@ using Microsoft.Extensions.Logging;
 using PackageCliTool.Models;
 using PackageCliTool.Models.Api;
 using PackageCliTool.Services;
+using PackageCliTool.Extensions;
+using PSW.Shared.Services;
 using Spectre.Console;
 
 namespace PackageCliTool.Workflows;
@@ -12,19 +14,19 @@ namespace PackageCliTool.Workflows;
 public class HistoryWorkflow
 {
     private readonly HistoryService _historyService;
-    private readonly ApiClient _apiClient;
     private readonly ScriptExecutor _scriptExecutor;
+    private readonly IScriptGeneratorService _scriptGeneratorService;
     private readonly ILogger? _logger;
 
     public HistoryWorkflow(
         HistoryService historyService,
-        ApiClient apiClient,
         ScriptExecutor scriptExecutor,
+        IScriptGeneratorService scriptGeneratorService,
         ILogger? logger = null)
     {
         _historyService = historyService;
-        _apiClient = apiClient;
         _scriptExecutor = scriptExecutor;
+        _scriptGeneratorService = scriptGeneratorService;
         _logger = logger;
     }
 
@@ -277,7 +279,7 @@ public class HistoryWorkflow
             .SpinnerStyle(Style.Parse("green"))
             .StartAsync("Regenerating installation script...", async ctx =>
             {
-                return await _apiClient.GenerateScriptAsync(scriptModel);
+                return await Task.Run(() => _scriptGeneratorService.GenerateScript(scriptModel.ToViewModel()));
             });
 
         _logger?.LogInformation("Script regenerated successfully");

--- a/src/PackageCliTool/Workflows/TemplateWorkflow.cs
+++ b/src/PackageCliTool/Workflows/TemplateWorkflow.cs
@@ -5,6 +5,8 @@ using PackageCliTool.Models.Templates;
 using PackageCliTool.Services;
 using PackageCliTool.Validation;
 using PackageCliTool.Exceptions;
+using PackageCliTool.Extensions;
+using PSW.Shared.Services;
 
 namespace PackageCliTool.Workflows;
 
@@ -14,19 +16,19 @@ namespace PackageCliTool.Workflows;
 public class TemplateWorkflow
 {
     private readonly TemplateService _templateService;
-    private readonly ApiClient _apiClient;
     private readonly ScriptExecutor _scriptExecutor;
+    private readonly IScriptGeneratorService _scriptGeneratorService;
     private readonly ILogger? _logger;
 
     public TemplateWorkflow(
         TemplateService templateService,
-        ApiClient apiClient,
         ScriptExecutor scriptExecutor,
+        IScriptGeneratorService scriptGeneratorService,
         ILogger? logger = null)
     {
         _templateService = templateService;
-        _apiClient = apiClient;
         _scriptExecutor = scriptExecutor;
+        _scriptGeneratorService = scriptGeneratorService;
         _logger = logger;
     }
 
@@ -214,7 +216,7 @@ public class TemplateWorkflow
             .SpinnerStyle(Style.Parse("green"))
             .StartAsync("Generating installation script...", async ctx =>
             {
-                return await _apiClient.GenerateScriptAsync(scriptModel);
+                return await Task.Run(() => _scriptGeneratorService.GenerateScript(scriptModel.ToViewModel()));
             });
 
         _logger?.LogInformation("Script generated successfully");


### PR DESCRIPTION
PackageSelector changes:
- Replace GetAllPackagesAsync API call with GetAllPackagesFromUmbraco
- Add GetAllPackagesFromMarketplace method with IMemoryCache caching (60 min TTL)
- Use Task.Run to wrap synchronous call for Spectre Console compatibility

HistoryWorkflow changes:
- Replace ApiClient dependency with IScriptGeneratorService
- Update GenerateScriptAsync to use scriptGeneratorService.GenerateScript
- Add using statements for PackageCliTool.Extensions and PSW.Shared.Services

TemplateWorkflow changes:
- Replace ApiClient dependency with IScriptGeneratorService
- Update GenerateScriptAsync to use scriptGeneratorService.GenerateScript
- Add using statements for PackageCliTool.Extensions and PSW.Shared.Services

Program.cs changes:
- Update HistoryWorkflow instantiation to pass IScriptGeneratorService
- Update TemplateWorkflow instantiation to pass IScriptGeneratorService

The CLI tool now uses shared services from PSW.Shared exclusively and no longer makes HTTP calls to the PSW API. All data fetching happens directly:
- Package versions from NuGet API (via MarketplacePackageService)
- Package list from Umbraco Marketplace API (via MarketplacePackageService)
- Script generation via ScriptGeneratorService (in-process)