### PR TITLE
Reorder template prompts before package selection

### DIFF
--- a/src/PackageCliTool/README.md
+++ b/src/PackageCliTool/README.md
@@ -330,7 +330,11 @@ psw -p "uSync|17.0.0" -n QuickSite -o -r
 
 Package Script Writer - Interactive CLI
 
-Step 1: Select Packages
+Step 1: Select Template
+
+Step 2: Select Template Version
+
+Step 3: Select Packages
 
 Select one or more packages (use Space to select, Enter to confirm):
   [ ] Umbraco.Community.BlockPreview
@@ -339,13 +343,13 @@ Select one or more packages (use Space to select, Enter to confirm):
   [ ] Umbraco.Community.Contentment
   ...
 
-Step 2: Select Versions
+Step 4: Select Versions
 
 ⠋ Fetching versions for Diplo.GodMode...
 ✓ Selected Diplo.GodMode version 3.0.3
 ✓ Selected uSync version 12.0.0
 
-Step 3: Final Selection
+Step 5: Final Selection
 
 ┌───────────────────────────┬──────────────────┐
 │      Package Name         │ Selected Version │
@@ -356,7 +360,7 @@ Step 3: Final Selection
 
 Would you like to generate a complete installation script? (y/n): y
 
-Step 4: Configure Project Options
+Step 6: Configure Project Options
 
 Template & Project Settings
 

--- a/src/PackageCliTool/Services/PackageSelector.cs
+++ b/src/PackageCliTool/Services/PackageSelector.cs
@@ -103,7 +103,7 @@ public class PackageSelector
     /// </summary>
     public async Task<List<string>> SelectPackagesAsync()
     {
-        AnsiConsole.MarkupLine("[bold blue]Step 1:[/] Select Packages\n");
+        AnsiConsole.MarkupLine("[bold blue]Step 3:[/] Select Packages\n");
 
         // Ask user how they want to select packages
         var selectionMode = AnsiConsole.Prompt(
@@ -269,7 +269,7 @@ public class PackageSelector
     public Dictionary<string, string> SelectVersionsForPackages(List<string> packages)
     {
         AnsiConsole.WriteLine();
-        AnsiConsole.MarkupLine("[bold blue]Step 2:[/] Select Versions\n");
+        AnsiConsole.MarkupLine("[bold blue]Step 4:[/] Select Versions\n");
 
         var packageVersions = new Dictionary<string, string>();
 

--- a/src/PackageCliTool/UI/ConfigurationDisplay.cs
+++ b/src/PackageCliTool/UI/ConfigurationDisplay.cs
@@ -14,7 +14,7 @@ public static class ConfigurationDisplay
     public static void DisplayFinalSelection(Dictionary<string, string> packageVersions)
     {
         AnsiConsole.WriteLine();
-        AnsiConsole.MarkupLine("[bold blue]Step 3:[/] Final Selection\n");
+        AnsiConsole.MarkupLine("[bold blue]Step 5:[/] Final Selection\n");
 
         if (packageVersions.Count == 0)
         {

--- a/src/PackageCliTool/UI/InteractivePrompts.cs
+++ b/src/PackageCliTool/UI/InteractivePrompts.cs
@@ -17,7 +17,7 @@ public static class InteractivePrompts
     public static async Task<ScriptModel> PromptForScriptConfigurationAsync(Dictionary<string, string> packageVersions, ApiClient apiClient, ILogger? logger = null, string? templateName = null, string? templateVersion = null, ScriptModel? existingModel = null)
     {
         AnsiConsole.WriteLine();
-        AnsiConsole.MarkupLine("[bold blue]Step 7:[/] Configure Project Options\n");
+        AnsiConsole.MarkupLine("[bold blue]Step 5:[/] Configure Project Options\n");
 
         // Build packages string with proper format handling
         var packageParts = new List<string>();

--- a/src/PackageCliTool/Workflows/InteractiveModeWorkflow.cs
+++ b/src/PackageCliTool/Workflows/InteractiveModeWorkflow.cs
@@ -121,7 +121,15 @@ public class InteractiveModeWorkflow
     {
         _logger?.LogInformation("Starting custom configuration flow");
 
-        // Step 1: Select packages
+        // Step 1: Select template
+        AnsiConsole.WriteLine();
+        AnsiConsole.MarkupLine("[bold blue]Step 1:[/] Select Template\n");
+        var templateName = await _packageSelector.SelectTemplateAsync();
+
+        // Step 2: Select template version
+        var templateVersion = _packageSelector.SelectTemplateVersion(templateName);
+
+        // Step 3: Select packages
         var selectedPackages = await _packageSelector.SelectPackagesAsync();
 
         if (selectedPackages.Count == 0)
@@ -133,21 +141,13 @@ public class InteractiveModeWorkflow
             var shouldGenerate = AnsiConsole.Confirm("Would you like to generate a complete installation script?");
             if (shouldGenerate)
             {
-                await GenerateAndDisplayScriptAsync(new Dictionary<string, string>());
+                await GenerateAndDisplayScriptAsync(new Dictionary<string, string>(), templateName, templateVersion);
             }
             return;
         }
 
-        // Step 2: For each package, select version
+        // Step 4: For each package, select version
         var packageVersions = _packageSelector.SelectVersionsForPackages(selectedPackages);
-
-        // Step 3: Select template
-        AnsiConsole.WriteLine();
-        AnsiConsole.MarkupLine("[bold blue]Step 3:[/] Select Template\n");
-        var templateName = await _packageSelector.SelectTemplateAsync();
-
-        // Step 4: Select template version
-        var templateVersion = _packageSelector.SelectTemplateVersion(templateName);
 
         // Step 5: Display final selection
         ConfigurationDisplay.DisplayFinalSelection(packageVersions);


### PR DESCRIPTION
When users decline the default script, they are now asked to select:
1. Template first
2. Template version second
3. Packages third
4. Package versions fourth

This provides a more logical flow by establishing the project foundation
(template) before selecting additional packages to install.

Updated step numbers across all affected files:
- InteractiveModeWorkflow.cs: Reordered execution flow
- PackageSelector.cs: Updated step numbers (1→3, 2→4)
- ConfigurationDisplay.cs: Updated step number (3→5)
- InteractivePrompts.cs: Updated step number (7→5)
- README.md: Updated documentation to reflect new flow