### PR TITLE
Replace memory cache with file-based JSON cache for packages

### DIFF
--- a/src/PackageCliTool/Models/CommandLineOptions.cs
+++ b/src/PackageCliTool/Models/CommandLineOptions.cs
@@ -48,6 +48,7 @@ public class CommandLineOptions
     // Cache-related options
     public bool NoCache { get; set; }  // Disable caching
     public bool ClearCache { get; set; }  // Clear all cache
+    public bool UpdatePackageCache { get; set; }  // Force update package cache from marketplace
 
     /// <summary>
     /// Checks if this is a template command
@@ -293,6 +294,10 @@ public class CommandLineOptions
 
                 case "--clear-cache":
                     options.ClearCache = true;
+                    break;
+
+                case "--update-packages":
+                    options.UpdatePackageCache = true;
                     break;
 
                 default:

--- a/src/PackageCliTool/Services/PackageCacheService.cs
+++ b/src/PackageCliTool/Services/PackageCacheService.cs
@@ -1,0 +1,111 @@
+using Microsoft.Extensions.Logging;
+using System.Text.Json;
+using PSW.Shared.Models;
+
+namespace PackageCliTool.Services;
+
+/// <summary>
+/// Service for managing file-based package caching
+/// </summary>
+public class PackageCacheService
+{
+    private readonly string _cacheFile;
+    private readonly ILogger? _logger;
+    private readonly JsonSerializerOptions _jsonOptions;
+
+    public PackageCacheService(ILogger? logger = null)
+    {
+        _logger = logger;
+
+        // Store cache file next to the executable
+        var baseDir = AppContext.BaseDirectory;
+        _cacheFile = Path.Combine(baseDir, "packages-cache.json");
+
+        _jsonOptions = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            PropertyNameCaseInsensitive = true
+        };
+
+        _logger?.LogDebug("Package cache file location: {CacheFile}", _cacheFile);
+    }
+
+    /// <summary>
+    /// Checks if the cache file exists
+    /// </summary>
+    public bool CacheExists()
+    {
+        return File.Exists(_cacheFile);
+    }
+
+    /// <summary>
+    /// Gets the cached packages from file
+    /// </summary>
+    public List<PagedPackagesPackage>? GetCachedPackages()
+    {
+        if (!File.Exists(_cacheFile))
+        {
+            _logger?.LogDebug("Package cache file not found");
+            return null;
+        }
+
+        try
+        {
+            var json = File.ReadAllText(_cacheFile);
+            var packages = JsonSerializer.Deserialize<List<PagedPackagesPackage>>(json, _jsonOptions);
+
+            _logger?.LogInformation("Loaded {Count} packages from cache file", packages?.Count ?? 0);
+            return packages;
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Failed to read package cache file");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Saves packages to the cache file
+    /// </summary>
+    public void SavePackages(List<PagedPackagesPackage> packages)
+    {
+        try
+        {
+            var json = JsonSerializer.Serialize(packages, _jsonOptions);
+            File.WriteAllText(_cacheFile, json);
+
+            _logger?.LogInformation("Saved {Count} packages to cache file: {CacheFile}", packages.Count, _cacheFile);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Failed to save package cache file");
+        }
+    }
+
+    /// <summary>
+    /// Clears the package cache file
+    /// </summary>
+    public void ClearCache()
+    {
+        try
+        {
+            if (File.Exists(_cacheFile))
+            {
+                File.Delete(_cacheFile);
+                _logger?.LogInformation("Deleted package cache file: {CacheFile}", _cacheFile);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Failed to delete package cache file");
+        }
+    }
+
+    /// <summary>
+    /// Gets the cache file path
+    /// </summary>
+    public string GetCacheFilePath()
+    {
+        return _cacheFile;
+    }
+}

--- a/src/PackageCliTool/UI/ConsoleDisplay.cs
+++ b/src/PackageCliTool/UI/ConsoleDisplay.cs
@@ -109,6 +109,7 @@ public static class ConsoleDisplay
 [bold yellow]CACHE OPTIONS:[/]
   [green]    --no-cache[/]                Disable API response caching (bypass cache)
   [green]    --clear-cache[/]             Clear all cached API responses
+  [green]    --update-packages[/]         Update package list cache from marketplace
 
 [bold yellow]EXECUTION:[/]
   [green]    --auto-run[/]                Automatically run the generated script
@@ -171,6 +172,9 @@ public static class ConsoleDisplay
 [bold yellow]CACHE EXAMPLES:[/]
   Clear the cache:
     [cyan]psw --clear-cache[/]
+
+  Update package list from marketplace:
+    [cyan]psw --update-packages[/]
 
   Generate script without using cache:
     [cyan]psw --default --no-cache[/]


### PR DESCRIPTION
- Created PackageCacheService to manage JSON file cache (packages-cache.json) stored next to the executable
- Updated PackageSelector to use file-based cache instead of IMemoryCache
  - First run loads from marketplace API and saves to cache file
  - Subsequent runs load instantly from cache file
  - Added forceUpdate parameter to PopulateAllPackages method
- Added --update-packages flag to force refresh package cache from marketplace
- Updated --clear-cache to also clear package cache file
- Updated help documentation with new flag and usage examples

This improves performance significantly after first run by avoiding slow marketplace API calls.