### PR TITLE
Add version check feature to interactive CLI mode

### DIFF
--- a/src/PackageCliTool/Program.cs
+++ b/src/PackageCliTool/Program.cs
@@ -135,6 +135,8 @@ class Program
             var scriptExecutor = new ScriptExecutor(logger);
             var templateService = new TemplateService(logger: logger);
             var historyService = new HistoryService(logger: logger);
+            var httpClientFactory = serviceProvider.GetRequiredService<IHttpClientFactory>();
+            var versionCheckService = new VersionCheckService(httpClientFactory.CreateClient(), logger);
 
             // Check if this is a history command
             if (options.IsHistoryCommand())
@@ -167,6 +169,7 @@ class Program
                             packageSelector,
                             scriptExecutor,
                             scriptGeneratorService,
+                            versionCheckService,
                             logger);
                         await interactiveWorkflow.RunAsync();
                         keepRunning = false; // Exit loop on normal completion

--- a/src/PackageCliTool/Services/VersionCheckService.cs
+++ b/src/PackageCliTool/Services/VersionCheckService.cs
@@ -1,0 +1,198 @@
+using Microsoft.Extensions.Logging;
+using PackageCliTool.Configuration;
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+
+namespace PackageCliTool.Services;
+
+/// <summary>
+/// Service for checking if a newer version of the CLI tool is available
+/// </summary>
+public class VersionCheckService
+{
+    private const string NuGetApiBaseUrl = "https://api.nuget.org/v3/registration5-semver1";
+    private const string PackageId = "PackageScriptWriter.Cli";
+    private readonly HttpClient _httpClient;
+    private readonly ILogger? _logger;
+
+    public VersionCheckService(HttpClient httpClient, ILogger? logger = null)
+    {
+        _httpClient = httpClient;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Checks if a newer version is available on NuGet
+    /// </summary>
+    /// <returns>Version information if a newer version is available, null otherwise</returns>
+    public async Task<VersionCheckResult?> CheckForUpdateAsync()
+    {
+        try
+        {
+            _logger?.LogDebug("Checking for updates to {PackageId}", PackageId);
+
+            var url = $"{NuGetApiBaseUrl}/{PackageId.ToLowerInvariant()}/index.json";
+            var response = await _httpClient.GetFromJsonAsync<NuGetRegistrationResponse>(url);
+
+            if (response?.Items == null || response.Items.Count == 0)
+            {
+                _logger?.LogWarning("No package information found on NuGet");
+                return null;
+            }
+
+            // Get all versions from the catalog
+            var allVersions = new List<string>();
+            foreach (var item in response.Items)
+            {
+                if (item.Items != null)
+                {
+                    allVersions.AddRange(item.Items.Select(v => v.CatalogEntry?.Version).Where(v => v != null)!);
+                }
+            }
+
+            if (allVersions.Count == 0)
+            {
+                _logger?.LogWarning("No versions found in NuGet package catalog");
+                return null;
+            }
+
+            // Get the latest stable version (exclude prerelease)
+            var latestVersion = allVersions
+                .Where(v => !v.Contains("-"))
+                .OrderByDescending(v => ParseVersion(v))
+                .FirstOrDefault();
+
+            // If no stable version, get latest prerelease
+            if (latestVersion == null)
+            {
+                latestVersion = allVersions
+                    .OrderByDescending(v => ParseVersion(v))
+                    .FirstOrDefault();
+            }
+
+            if (latestVersion == null)
+            {
+                _logger?.LogWarning("Could not determine latest version");
+                return null;
+            }
+
+            var currentVersion = ApiConfiguration.Version;
+            _logger?.LogDebug("Current version: {Current}, Latest version: {Latest}", currentVersion, latestVersion);
+
+            // Compare versions
+            if (IsNewerVersion(latestVersion, currentVersion))
+            {
+                _logger?.LogInformation("Newer version available: {Latest}", latestVersion);
+                return new VersionCheckResult
+                {
+                    IsUpdateAvailable = true,
+                    CurrentVersion = currentVersion,
+                    LatestVersion = latestVersion,
+                    UpdateCommand = $"dotnet tool update -g {PackageId}"
+                };
+            }
+
+            _logger?.LogDebug("No update available. Current version is up to date.");
+            return new VersionCheckResult
+            {
+                IsUpdateAvailable = false,
+                CurrentVersion = currentVersion,
+                LatestVersion = latestVersion,
+                UpdateCommand = $"dotnet tool update -g {PackageId}"
+            };
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger?.LogDebug(ex, "Failed to check for updates (network error)");
+            return null;
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogDebug(ex, "Failed to check for updates");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Compares two version strings to determine if the first is newer than the second
+    /// </summary>
+    private bool IsNewerVersion(string version1, string version2)
+    {
+        var v1 = ParseVersion(version1);
+        var v2 = ParseVersion(version2);
+
+        // Compare major.minor.patch
+        if (v1.Major != v2.Major) return v1.Major > v2.Major;
+        if (v1.Minor != v2.Minor) return v1.Minor > v2.Minor;
+        if (v1.Patch != v2.Patch) return v1.Patch > v2.Patch;
+
+        // If both are stable, they're equal
+        if (string.IsNullOrEmpty(v1.Prerelease) && string.IsNullOrEmpty(v2.Prerelease))
+            return false;
+
+        // Stable version is newer than prerelease
+        if (string.IsNullOrEmpty(v1.Prerelease) && !string.IsNullOrEmpty(v2.Prerelease))
+            return true;
+
+        if (!string.IsNullOrEmpty(v1.Prerelease) && string.IsNullOrEmpty(v2.Prerelease))
+            return false;
+
+        // Both are prerelease, compare prerelease strings
+        return string.Compare(v1.Prerelease, v2.Prerelease, StringComparison.OrdinalIgnoreCase) > 0;
+    }
+
+    /// <summary>
+    /// Parses a version string into its components
+    /// </summary>
+    private (int Major, int Minor, int Patch, string Prerelease) ParseVersion(string version)
+    {
+        var parts = version.Split('-', 2);
+        var versionPart = parts[0];
+        var prereleasePart = parts.Length > 1 ? parts[1] : string.Empty;
+
+        var versionNumbers = versionPart.Split('.');
+        var major = versionNumbers.Length > 0 ? int.TryParse(versionNumbers[0], out var m) ? m : 0 : 0;
+        var minor = versionNumbers.Length > 1 ? int.TryParse(versionNumbers[1], out var n) ? n : 0 : 0;
+        var patch = versionNumbers.Length > 2 ? int.TryParse(versionNumbers[2], out var p) ? p : 0 : 0;
+
+        return (major, minor, patch, prereleasePart);
+    }
+}
+
+/// <summary>
+/// Result of a version check operation
+/// </summary>
+public class VersionCheckResult
+{
+    public bool IsUpdateAvailable { get; set; }
+    public string CurrentVersion { get; set; } = string.Empty;
+    public string LatestVersion { get; set; } = string.Empty;
+    public string UpdateCommand { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// NuGet API response models
+/// </summary>
+internal class NuGetRegistrationResponse
+{
+    [JsonPropertyName("items")]
+    public List<NuGetRegistrationPage>? Items { get; set; }
+}
+
+internal class NuGetRegistrationPage
+{
+    [JsonPropertyName("items")]
+    public List<NuGetRegistrationLeaf>? Items { get; set; }
+}
+
+internal class NuGetRegistrationLeaf
+{
+    [JsonPropertyName("catalogEntry")]
+    public NuGetCatalogEntry? CatalogEntry { get; set; }
+}
+
+internal class NuGetCatalogEntry
+{
+    [JsonPropertyName("version")]
+    public string? Version { get; set; }
+}


### PR DESCRIPTION
Added automatic version checking when the interactive CLI starts. The tool now checks NuGet for newer versions and displays a friendly notification to users if an update is available.

Changes:
- Created VersionCheckService to check NuGet API for latest package version
- Integrated version check into InteractiveModeWorkflow after welcome banner
- Added non-blocking version check with silent failure to avoid disrupting UX
- Displays update command to users when newer version is detected

The version check gracefully handles network errors and won't interrupt the user's workflow if the check fails.