### PR TITLE
Fix template and history commands to display help instead of starting interactive mode

### DIFF
--- a/src/PackageCliTool/Models/CommandLineOptions.cs
+++ b/src/PackageCliTool/Models/CommandLineOptions.cs
@@ -229,6 +229,11 @@ public class CommandLineOptions
                             options.TemplateName = args[i];
                         }
                     }
+                    else
+                    {
+                        // No subcommand provided - set to empty string to trigger help display
+                        options.TemplateCommand = "";
+                    }
                     break;
 
                 case "--template-name":
@@ -277,6 +282,11 @@ public class CommandLineOptions
                             i++;
                             options.HistoryId = args[i];
                         }
+                    }
+                    else
+                    {
+                        // No subcommand provided - set to empty string to trigger help display
+                        options.HistoryCommand = "";
                     }
                     break;
 

--- a/src/PackageCliTool/UI/ConsoleDisplay.cs
+++ b/src/PackageCliTool/UI/ConsoleDisplay.cs
@@ -190,6 +190,100 @@ public static class ConsoleDisplay
     }
 
     /// <summary>
+    /// Displays help information for template commands
+    /// </summary>
+    public static void DisplayTemplateHelp()
+    {
+        var helpPanel = new Panel(
+            @"[bold yellow]USAGE:[/]
+  psw template <command> [[options]]
+
+[bold yellow]TEMPLATE COMMANDS:[/]
+  [green]save[/] <name>          Save current configuration as a template
+  [green]load[/] <name>          Load and execute a template
+  [green]list[/]                 List all available templates
+  [green]show[/] <name>          Show template details
+  [green]delete[/] <name>        Delete a template
+  [green]export[/] <name>        Export template to file
+  [green]import[/] <file>        Import template from file
+  [green]validate[/] <file>      Validate template file
+
+[bold yellow]TEMPLATE OPTIONS:[/]
+  [green]    --template-description[/] <desc> Template description
+  [green]    --template-tags[/] <tags>   Comma-separated tags
+  [green]    --template-file[/] <path>   Template file path
+  [green]    --set[/] <key=value>        Override template values
+
+[bold yellow]EXAMPLES:[/]
+  Save current configuration as template:
+    [cyan]psw template save my-blog --template-description ""My blog setup"" --template-tags ""blog,umbraco14""[/]
+
+  List all templates:
+    [cyan]psw template list[/]
+
+  Load and use a template:
+    [cyan]psw template load my-blog[/]
+
+  Load template with overrides:
+    [cyan]psw template load my-blog --project-name NewBlog --set AutoRun=true[/]
+
+  Export template to file:
+    [cyan]psw template export my-blog --template-file my-blog.yaml[/]
+
+  Import template from file:
+    [cyan]psw template import my-blog.yaml[/]")
+            .Header("[bold blue]Template Command Help[/]")
+            .Border(BoxBorder.Rounded)
+            .BorderColor(Color.Blue)
+            .Padding(1, 1);
+
+        AnsiConsole.Write(helpPanel);
+    }
+
+    /// <summary>
+    /// Displays help information for history commands
+    /// </summary>
+    public static void DisplayHistoryHelp()
+    {
+        var helpPanel = new Panel(
+            @"[bold yellow]USAGE:[/]
+  psw history <command> [[options]]
+
+[bold yellow]HISTORY COMMANDS:[/]
+  [green]list[/]                  List recent script generation history
+  [green]show[/] <#>              Show details of a history entry
+  [green]rerun[/] <#>             Regenerate and re-run a script from history
+  [green]delete[/] <#>            Delete a history entry
+  [green]clear[/]                 Clear all history
+  [green]stats[/]                 Show history statistics
+
+[bold yellow]HISTORY OPTIONS:[/]
+  [green]    --history-limit[/] <count>  Number of entries to show (default: 10)
+
+[bold yellow]EXAMPLES:[/]
+  List recent scripts:
+    [cyan]psw history list[/]
+
+  Show details of a specific entry:
+    [cyan]psw history show 3[/]
+
+  Re-run a previous script:
+    [cyan]psw history rerun 1[/]
+
+  View statistics:
+    [cyan]psw history stats[/]
+
+  Clear all history:
+    [cyan]psw history clear[/]")
+            .Header("[bold blue]History Command Help[/]")
+            .Border(BoxBorder.Rounded)
+            .BorderColor(Color.Blue)
+            .Padding(1, 1);
+
+        AnsiConsole.Write(helpPanel);
+    }
+
+    /// <summary>
     /// Displays version information
     /// </summary>
     public static void DisplayVersion()

--- a/src/PackageCliTool/Workflows/HistoryWorkflow.cs
+++ b/src/PackageCliTool/Workflows/HistoryWorkflow.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Logging;
 using PackageCliTool.Models;
 using PackageCliTool.Models.Api;
 using PackageCliTool.Services;
+using PackageCliTool.UI;
 using PackageCliTool.Extensions;
 using PSW.Shared.Services;
 using Spectre.Console;
@@ -37,6 +38,15 @@ public class HistoryWorkflow
     {
         var command = options.HistoryCommand?.ToLower();
 
+        // If no command was provided (e.g., just "psw history"), show help
+        if (string.IsNullOrEmpty(command))
+        {
+            AnsiConsole.MarkupLine("[red]Error: Missing history subcommand[/]\n");
+            ConsoleDisplay.DisplayHistoryHelp();
+            Environment.ExitCode = 1;
+            return;
+        }
+
         switch (command)
         {
             case "list":
@@ -65,8 +75,9 @@ public class HistoryWorkflow
                 break;
 
             default:
-                AnsiConsole.MarkupLine($"[red]Unknown history command: {command}[/]");
-                AnsiConsole.MarkupLine("Use [green]psw history --help[/] for available commands");
+                AnsiConsole.MarkupLine($"[red]Error: Unknown history command '{command}'[/]\n");
+                ConsoleDisplay.DisplayHistoryHelp();
+                Environment.ExitCode = 1;
                 break;
         }
     }

--- a/src/PackageCliTool/Workflows/TemplateWorkflow.cs
+++ b/src/PackageCliTool/Workflows/TemplateWorkflow.cs
@@ -3,6 +3,7 @@ using Spectre.Console;
 using PackageCliTool.Models;
 using PackageCliTool.Models.Templates;
 using PackageCliTool.Services;
+using PackageCliTool.UI;
 using PackageCliTool.Validation;
 using PackageCliTool.Exceptions;
 using PackageCliTool.Extensions;
@@ -39,6 +40,15 @@ public class TemplateWorkflow
     {
         var command = options.TemplateCommand?.ToLower();
 
+        // If no command was provided (e.g., just "psw template"), show help
+        if (string.IsNullOrEmpty(command))
+        {
+            AnsiConsole.MarkupLine("[red]Error: Missing template subcommand[/]\n");
+            ConsoleDisplay.DisplayTemplateHelp();
+            Environment.ExitCode = 1;
+            return;
+        }
+
         switch (command)
         {
             case "save":
@@ -74,8 +84,9 @@ public class TemplateWorkflow
                 break;
 
             default:
-                AnsiConsole.MarkupLine($"[red]Unknown template command: {command}[/]");
-                AnsiConsole.MarkupLine("Use [green]psw template --help[/] for available commands");
+                AnsiConsole.MarkupLine($"[red]Error: Unknown template command '{command}'[/]\n");
+                ConsoleDisplay.DisplayTemplateHelp();
+                Environment.ExitCode = 1;
                 break;
         }
     }


### PR DESCRIPTION
When running 'psw template' or 'psw history' without a subcommand, the CLI now displays
an error message and the relevant command help instead of falling through to interactive mode.

Changes:
- Modified CommandLineOptions.Parse to set TemplateCommand/HistoryCommand to empty string when
  the verb is provided without a subcommand
- Added DisplayTemplateHelp() and DisplayHistoryHelp() methods to ConsoleDisplay
- Updated TemplateWorkflow and HistoryWorkflow to check for null/empty commands and display
  appropriate help with error messages
- Set Environment.ExitCode = 1 for invalid command usage

This ensures users get immediate feedback when they forget to specify a subcommand.