### PR TITLE
Enhance diagnostic tool to identify IPv6 timeout issue

### DIFF
--- a/src/PSW.ApiDiagnostic/Program.cs
+++ b/src/PSW.ApiDiagnostic/Program.cs
@@ -1,48 +1,248 @@
 using System.Diagnostics;
 using System.Net;
+using System.Net.Sockets;
 
 namespace PSW.ApiDiagnostic;
 
 class Program
 {
     private const string ApiUrl = "https://psw.codeshare.co.uk/api/scriptgeneratorapi/test";
+    private const string Hostname = "psw.codeshare.co.uk";
 
     // Static HttpClient - best practice for reuse
     private static readonly HttpClient StaticClient = new();
 
     static async Task Main(string[] args)
     {
-        Console.WriteLine("=== API Performance Diagnostic Tool ===\n");
+        Console.WriteLine("=== API Performance Diagnostic Tool (Enhanced) ===\n");
         Console.WriteLine($"Testing endpoint: {ApiUrl}\n");
+
+        // New Test: DNS Resolution
+        Console.WriteLine("=== PHASE 1: DNS & Network Analysis ===\n");
+
+        Console.WriteLine("Test A: DNS Resolution");
+        await TestDnsResolution();
+        Console.WriteLine();
+
+        // New Test: IPv4 vs IPv6
+        Console.WriteLine("Test B: IPv4 vs IPv6 Connectivity");
+        await TestIpVersions();
+        Console.WriteLine();
+
+        // New Test: Raw TCP Connection
+        Console.WriteLine("Test C: Raw TCP Connection Speed (Port 443)");
+        await TestRawTcpConnection();
+        Console.WriteLine();
+
+        Console.WriteLine("=== PHASE 2: HTTP Client Tests ===\n");
 
         // Test 1: Using a static/reused HttpClient (recommended)
         Console.WriteLine("Test 1: Static/Reused HttpClient");
         await TestWithStaticClient();
         Console.WriteLine();
 
-        // Test 2: Creating a new HttpClient each time (anti-pattern)
-        Console.WriteLine("Test 2: New HttpClient Instance (Anti-Pattern)");
-        await TestWithNewClient();
+        // Test 2: Force IPv4 only
+        Console.WriteLine("Test 2: Force IPv4 Only");
+        await TestWithIpv4Only();
         Console.WriteLine();
 
-        // Test 3: Using HttpClient with explicit connection settings
-        Console.WriteLine("Test 3: HttpClient with Connection Keep-Alive");
-        await TestWithKeepAlive();
+        // Test 3: Force IPv6 only (if available)
+        Console.WriteLine("Test 3: Force IPv6 Only");
+        await TestWithIpv6Only();
         Console.WriteLine();
 
-        // Test 4: Using HttpClient with DNS refresh disabled
-        Console.WriteLine("Test 4: HttpClient with SocketsHttpHandler (No DNS Caching Issues)");
-        await TestWithSocketsHttpHandler();
-        Console.WriteLine();
-
-        // Test 5: Multiple sequential requests with static client
-        Console.WriteLine("Test 5: Three Sequential Requests (Static Client)");
+        // Test 4: Multiple sequential requests with static client
+        Console.WriteLine("Test 4: Three Sequential Requests (Static Client - Reuse Connection)");
         await TestMultipleRequests();
         Console.WriteLine();
 
         Console.WriteLine("=== Diagnostic Complete ===");
+
+        Console.WriteLine("\n=== ANALYSIS ===");
+        Console.WriteLine("If DNS resolution is fast but first HTTP request is slow:");
+        Console.WriteLine("  → Likely TLS/SSL handshake or IPv6 fallback issue");
+        Console.WriteLine("\nIf IPv6 test times out or takes ~40s:");
+        Console.WriteLine("  → Your system is trying IPv6 first and timing out");
+        Console.WriteLine("  → Solution: Force IPv4 or disable IPv6 fallback");
+        Console.WriteLine("\nIf subsequent requests are fast:");
+        Console.WriteLine("  → Connection reuse works - keep connections alive!");
+
         Console.WriteLine("\nPress any key to exit...");
         Console.ReadKey();
+    }
+
+    static async Task TestDnsResolution()
+    {
+        var sw = Stopwatch.StartNew();
+        try
+        {
+            var addresses = await Dns.GetHostAddressesAsync(Hostname);
+            sw.Stop();
+
+            Console.WriteLine($"✓ DNS Resolution Time: {sw.ElapsedMilliseconds}ms");
+            Console.WriteLine($"✓ IP Addresses found:");
+            foreach (var addr in addresses)
+            {
+                Console.WriteLine($"  - {addr} ({addr.AddressFamily})");
+            }
+        }
+        catch (Exception ex)
+        {
+            sw.Stop();
+            Console.WriteLine($"✗ DNS Resolution failed after {sw.ElapsedMilliseconds}ms");
+            Console.WriteLine($"✗ Error: {ex.Message}");
+        }
+    }
+
+    static async Task TestIpVersions()
+    {
+        var addresses = await Dns.GetHostAddressesAsync(Hostname);
+
+        var ipv4 = addresses.FirstOrDefault(a => a.AddressFamily == AddressFamily.InterNetwork);
+        var ipv6 = addresses.FirstOrDefault(a => a.AddressFamily == AddressFamily.InterNetworkV6);
+
+        if (ipv4 != null)
+        {
+            Console.WriteLine($"\nIPv4 ({ipv4}):");
+            await TestTcpConnect(ipv4, 443);
+        }
+        else
+        {
+            Console.WriteLine("✗ No IPv4 address found");
+        }
+
+        if (ipv6 != null)
+        {
+            Console.WriteLine($"\nIPv6 ({ipv6}):");
+            await TestTcpConnect(ipv6, 443);
+        }
+        else
+        {
+            Console.WriteLine("✗ No IPv6 address found");
+        }
+    }
+
+    static async Task TestTcpConnect(IPAddress address, int port)
+    {
+        var sw = Stopwatch.StartNew();
+        try
+        {
+            using var client = new TcpClient(address.AddressFamily);
+            await client.ConnectAsync(address, port);
+            sw.Stop();
+            Console.WriteLine($"  ✓ TCP Connect Time: {sw.ElapsedMilliseconds}ms");
+            client.Close();
+        }
+        catch (Exception ex)
+        {
+            sw.Stop();
+            Console.WriteLine($"  ✗ TCP Connect failed after {sw.ElapsedMilliseconds}ms");
+            Console.WriteLine($"  ✗ Error: {ex.Message}");
+        }
+    }
+
+    static async Task TestRawTcpConnection()
+    {
+        var sw = Stopwatch.StartNew();
+        try
+        {
+            using var client = new TcpClient();
+            await client.ConnectAsync(Hostname, 443);
+            sw.Stop();
+            Console.WriteLine($"✓ TCP Connection Time: {sw.ElapsedMilliseconds}ms");
+            client.Close();
+        }
+        catch (Exception ex)
+        {
+            sw.Stop();
+            Console.WriteLine($"✗ TCP Connection failed after {sw.ElapsedMilliseconds}ms");
+            Console.WriteLine($"✗ Error: {ex.Message}");
+        }
+    }
+
+    static async Task TestWithIpv4Only()
+    {
+        var sw = Stopwatch.StartNew();
+        try
+        {
+            var handler = new SocketsHttpHandler
+            {
+                ConnectCallback = async (context, cancellationToken) =>
+                {
+                    var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+                    socket.NoDelay = true;
+
+                    try
+                    {
+                        await socket.ConnectAsync(context.DnsEndPoint, cancellationToken);
+                        return new NetworkStream(socket, ownsSocket: true);
+                    }
+                    catch
+                    {
+                        socket.Dispose();
+                        throw;
+                    }
+                }
+            };
+
+            using var client = new HttpClient(handler);
+            var response = await client.GetAsync(ApiUrl);
+            sw.Stop();
+
+            var content = await response.Content.ReadAsStringAsync();
+            Console.WriteLine($"✓ Status: {response.StatusCode}");
+            Console.WriteLine($"✓ Time: {sw.ElapsedMilliseconds}ms");
+            Console.WriteLine($"✓ Response: {content}");
+        }
+        catch (Exception ex)
+        {
+            sw.Stop();
+            Console.WriteLine($"✗ Failed after {sw.ElapsedMilliseconds}ms");
+            Console.WriteLine($"✗ Error: {ex.Message}");
+        }
+    }
+
+    static async Task TestWithIpv6Only()
+    {
+        var sw = Stopwatch.StartNew();
+        try
+        {
+            var handler = new SocketsHttpHandler
+            {
+                ConnectCallback = async (context, cancellationToken) =>
+                {
+                    var socket = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp);
+                    socket.NoDelay = true;
+
+                    try
+                    {
+                        await socket.ConnectAsync(context.DnsEndPoint, cancellationToken);
+                        return new NetworkStream(socket, ownsSocket: true);
+                    }
+                    catch
+                    {
+                        socket.Dispose();
+                        throw;
+                    }
+                }
+            };
+
+            using var client = new HttpClient(handler);
+            client.Timeout = TimeSpan.FromSeconds(45); // Shorter timeout for IPv6 test
+            var response = await client.GetAsync(ApiUrl);
+            sw.Stop();
+
+            var content = await response.Content.ReadAsStringAsync();
+            Console.WriteLine($"✓ Status: {response.StatusCode}");
+            Console.WriteLine($"✓ Time: {sw.ElapsedMilliseconds}ms");
+            Console.WriteLine($"✓ Response: {content}");
+        }
+        catch (Exception ex)
+        {
+            sw.Stop();
+            Console.WriteLine($"✗ Failed after {sw.ElapsedMilliseconds}ms");
+            Console.WriteLine($"✗ Error: {ex.Message}");
+        }
     }
 
     static async Task TestWithStaticClient()

--- a/src/PSW.ApiDiagnostic/README.md
+++ b/src/PSW.ApiDiagnostic/README.md
@@ -1,8 +1,11 @@
-# PSW API Diagnostic Tool
+# PSW API Diagnostic Tool (Enhanced)
 
 ## Purpose
 
-This diagnostic tool tests various HttpClient configurations to identify performance issues when calling the Package Script Writer API. It helps diagnose why API calls might be taking 30+ seconds instead of sub-second response times.
+This diagnostic tool identifies why API calls are taking 40+ seconds when they should be < 1 second. Based on initial testing, we know:
+- ✅ The API itself is fast (< 100ms when connection is established)
+- ✅ Connection reuse works perfectly (subsequent requests: 37-113ms)
+- ❌ **Initial connection establishment takes ~42 seconds**
 
 ## Running the Tool
 
@@ -13,48 +16,147 @@ dotnet run
 
 ## What It Tests
 
-The tool runs 5 different test scenarios:
+The enhanced tool runs tests in two phases:
 
-### Test 1: Static/Reused HttpClient (✅ Best Practice)
-- Uses a static `HttpClient` instance that's reused across requests
-- This is the recommended approach for .NET applications
-- Should show the best performance after the first request
+### PHASE 1: Network & DNS Analysis
 
-### Test 2: New HttpClient Instance (❌ Anti-Pattern)
-- Creates a fresh `HttpClient` for each request
-- This is what your current code does in `ApiClient.cs:26-30`
-- **This is likely causing your performance issues**
-- Problems with this approach:
-  - Exhausts available sockets
-  - DNS resolution issues
-  - Connection pool exhaustion
-  - Each request has to establish a new TCP connection
+**Test A: DNS Resolution**
+- Measures how long DNS lookup takes
+- Lists all IP addresses (IPv4 and IPv6) for the hostname
+- **Expected:** < 100ms
+- **If slow:** DNS server issues
 
-### Test 3: HttpClient with Connection Keep-Alive
-- Explicitly sets connection headers
-- Tests if keep-alive improves performance
+**Test B: IPv4 vs IPv6 Connectivity**
+- Tests TCP connection to both IPv4 and IPv6 addresses separately
+- **This is the critical test!**
+- If IPv6 takes ~40 seconds or times out → **Found the problem!**
+- If IPv4 is fast but IPv6 is slow → Your system is attempting IPv6 first and timing out
 
-### Test 4: HttpClient with SocketsHttpHandler
-- Uses modern `SocketsHttpHandler` with optimized settings
-- Better connection pooling and DNS handling
+**Test C: Raw TCP Connection**
+- Tests basic TCP connection on port 443 (HTTPS)
+- Uses system default IP version preference
+- **Expected:** < 500ms
+- **If slow:** Network routing issues
 
-### Test 5: Multiple Sequential Requests
-- Makes 3 requests in a row with the static client
-- Should show improved performance on subsequent requests due to connection reuse
+### PHASE 2: HTTP Client Tests
 
-## Expected Results
+**Test 1: Static/Reused HttpClient**
+- Uses a static `HttpClient` instance (best practice)
+- First request may be slow, but connection is kept for reuse
 
-If the issue is HttpClient instantiation:
-- Test 1 should be fast (< 1 second)
-- Test 2 might be slow on first run, worse on subsequent runs
-- Tests 3-5 should be relatively fast
+**Test 2: Force IPv4 Only**
+- **THIS IS THE KEY TEST!**
+- Forces HttpClient to use only IPv4
+- If this is FAST (~100ms) but Test 1 was slow (~42s) → **IPv6 timeout is the issue**
 
-## The Root Cause
+**Test 3: Force IPv6 Only**
+- Forces HttpClient to use only IPv6
+- Will timeout/fail if IPv6 connectivity is broken
+- Timeout set to 45s to avoid long waits
 
-Your `ApiClient` class creates a new `HttpClient` for every instance:
+**Test 4: Three Sequential Requests**
+- Makes 3 requests using the same HttpClient
+- Demonstrates connection reuse
+- **Expected:** First request ~42s (if unfixed), subsequent requests < 200ms
+
+## Interpreting Results
+
+### Scenario 1: IPv6 Timeout (Most Likely)
+```
+Test B: IPv4 vs IPv6
+  IPv4: ✓ TCP Connect: 120ms
+  IPv6: ✗ TCP Connect failed after 42000ms (timeout)
+
+Test 2 (Force IPv4): ✓ 150ms
+Test 3 (Force IPv6): ✗ Failed after 45000ms
+```
+**Diagnosis:** Your system tries IPv6 first, waits ~40s for timeout, then falls back to IPv4.
+
+**Solution:** Force IPv4 in your application (see below).
+
+### Scenario 2: TLS/SSL Issue
+```
+Test B: Both IPv4 and IPv6 connect fast (< 200ms)
+Test 1: Takes 42 seconds
+```
+**Diagnosis:** TLS handshake is slow (certificate validation, cipher negotiation).
+
+**Solution:** Check TLS configuration, update .NET runtime, check for antivirus/proxy interference.
+
+### Scenario 3: Network/Proxy Issue
+```
+Test A: DNS fast
+Test B: TCP connections fast
+Test 1: Still slow
+```
+**Diagnosis:** HTTP(S) proxy, firewall, or network policy causing delays.
+
+**Solution:** Check proxy settings, corporate network policies, firewall rules.
+
+## The Fix: Force IPv4
+
+Based on the diagnostic results, if IPv6 is the issue, update your `ApiClient` or use this pattern:
+
+### Solution 1: Force IPv4 in SocketsHttpHandler
 
 ```csharp
-// src/PackageCliTool/Services/ApiClient.cs:26-30
+private static readonly HttpClient _httpClient = new HttpClient(new SocketsHttpHandler
+{
+    ConnectCallback = async (context, cancellationToken) =>
+    {
+        // Force IPv4
+        var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        socket.NoDelay = true;
+
+        try
+        {
+            await socket.ConnectAsync(context.DnsEndPoint, cancellationToken);
+            return new NetworkStream(socket, ownsSocket: true);
+        }
+        catch
+        {
+            socket.Dispose();
+            throw;
+        }
+    },
+    PooledConnectionLifetime = TimeSpan.FromMinutes(5),
+    PooledConnectionIdleTimeout = TimeSpan.FromMinutes(2)
+});
+```
+
+### Solution 2: System-Wide IPv4 Preference
+
+Add to your application startup or `runtimeconfig.json`:
+
+```json
+{
+  "configProperties": {
+    "System.Net.SocketsHttpHandler.UseSocketsHttpHandler": true,
+    "System.Net.PreferIPv4": true
+  }
+}
+```
+
+Or set an environment variable:
+```bash
+export DOTNET_SYSTEM_NET_SOCKETS_PREFER_IPV4=1
+```
+
+### Solution 3: AppContext Switch (Runtime)
+
+In your `Main` or startup code:
+
+```csharp
+AppContext.SetSwitch("System.Net.DisableIPv6", true);
+```
+
+## Original Issues in Your Code
+
+While investigating, we also identified these issues in `ApiClient.cs`:
+
+### Issue 1: Creating New HttpClient Instances (Line 26-30)
+```csharp
+// WRONG - Creates new HttpClient every time
 var httpClient = new HttpClient
 {
     BaseAddress = new Uri(baseUrl),
@@ -62,43 +164,71 @@ var httpClient = new HttpClient
 };
 ```
 
-This is a well-known anti-pattern in .NET that causes:
-1. **Socket exhaustion** - Each HttpClient maintains its own connection pool
-2. **DNS caching issues** - DNS changes aren't respected when using fresh instances
-3. **Performance degradation** - Each request must establish new TCP connections
-4. **Connection pool exhaustion** - The OS can run out of available ports
+**Problems:**
+- Socket exhaustion
+- Connection pool issues
+- No connection reuse between ApiClient instances
 
-## Recommended Fix
+**Fix:** Use static HttpClient or IHttpClientFactory
 
-Use one of these approaches:
+### Issue 2: No IPv4/IPv6 Control
+The code doesn't handle IPv6 fallback timeout issues, which is causing the 42-second delay.
 
-### Option 1: Static HttpClient (Simple)
+## Recommended Complete Fix for ApiClient
+
 ```csharp
-private static readonly HttpClient _httpClient = new HttpClient();
-```
-
-### Option 2: IHttpClientFactory (Recommended for DI)
-```csharp
-// In your DI configuration
-services.AddHttpClient<ApiClient>();
-
-// In ApiClient constructor
-public ApiClient(HttpClient httpClient, ILogger logger)
+public class ApiClient
 {
-    _httpClient = httpClient;
-    _logger = logger;
+    private static readonly HttpClient _httpClient;
+    private readonly string _baseUrl;
+    private readonly ILogger? _logger;
+
+    static ApiClient()
+    {
+        var handler = new SocketsHttpHandler
+        {
+            // Force IPv4 to avoid timeout
+            ConnectCallback = async (context, cancellationToken) =>
+            {
+                var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+                socket.NoDelay = true;
+
+                try
+                {
+                    await socket.ConnectAsync(context.DnsEndPoint, cancellationToken);
+                    return new NetworkStream(socket, ownsSocket: true);
+                }
+                catch
+                {
+                    socket.Dispose();
+                    throw;
+                }
+            },
+            PooledConnectionLifetime = TimeSpan.FromMinutes(5),
+            PooledConnectionIdleTimeout = TimeSpan.FromMinutes(2),
+            EnableMultipleHttp2Connections = true
+        };
+
+        _httpClient = new HttpClient(handler)
+        {
+            Timeout = TimeSpan.FromSeconds(90)
+        };
+    }
+
+    public ApiClient(string baseUrl, ILogger? logger = null)
+    {
+        _baseUrl = baseUrl;
+        _logger = logger;
+        // No longer create HttpClient here!
+    }
+
+    // Update methods to use _httpClient with full URLs
+    // since we can't set BaseAddress on static client
 }
-```
-
-### Option 3: SocketsHttpHandler (Manual control)
-```csharp
-private static readonly HttpClient _httpClient = new HttpClient(new SocketsHttpHandler
-{
-    PooledConnectionLifetime = TimeSpan.FromMinutes(2)
-});
 ```
 
 ## Additional Resources
 
 - [HttpClient Best Practices](https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/http/httpclient-guidelines)
-- [You're using HttpClient wrong](https://aspnetmonsters.com/2016/08/2016-08-27-httpclientwrong/)
+- [IPv6 Connectivity Issues in .NET](https://learn.microsoft.com/en-us/dotnet/core/compatibility/networking/6.0/socketshttphandler-uses-ipv6-first)
+- [SocketsHttpHandler Configuration](https://learn.microsoft.com/en-us/dotnet/api/system.net.http.socketshttphandler)


### PR DESCRIPTION
Based on initial diagnostic results showing:
- All first connections take exactly ~42 seconds
- Subsequent requests are fast (37-113ms)
- Connection reuse works perfectly

This points to an initial connection establishment issue, most likely IPv6 timeout.

Enhanced diagnostic tool now includes:

PHASE 1: Network & DNS Analysis
- Test A: DNS resolution timing and IP address listing
- Test B: Direct IPv4 vs IPv6 TCP connectivity tests
- Test C: Raw TCP connection speed measurement

PHASE 2: HTTP Client Tests
- Test 1: Static HttpClient (baseline)
- Test 2: Force IPv4 only (key test to confirm IPv6 issue)
- Test 3: Force IPv6 only (should timeout if IPv6 is broken)
- Test 4: Sequential requests showing connection reuse

The tool will identify if:
1. IPv6 timeout is causing the delay (most likely)
2. TLS/SSL handshake issues
3. Network/proxy configuration problems

Updated README with:
- Detailed interpretation of results
- Three solution approaches to force IPv4
- Complete fix for ApiClient with IPv4-only SocketsHttpHandler
- System-wide configuration options