### PR TITLE
Fix template name and version not updating in configuration editor

### DIFF
--- a/src/PackageCliTool/Workflows/InteractiveModeWorkflow.cs
+++ b/src/PackageCliTool/Workflows/InteractiveModeWorkflow.cs
@@ -591,9 +591,9 @@ public class InteractiveModeWorkflow
                 config.Packages = string.Join(",", packageParts);
             }
 
-            // Update template fields
-            config.TemplateName = templateName;
-            config.TemplateVersion = templateVersion;
+            // Sync template fields from config to local variables
+            templateName = config.TemplateName;
+            templateVersion = config.TemplateVersion;
 
             // Display configuration table
             AnsiConsole.WriteLine();
@@ -676,8 +676,8 @@ public class InteractiveModeWorkflow
         {
             case "Template":
                 AnsiConsole.MarkupLine("[bold blue]Select Template[/]\n");
-                templateName = await _packageSelector.SelectTemplateAsync();
-                templateVersion = await _packageSelector.SelectTemplateVersionAsync(templateName);
+                config.TemplateName = await _packageSelector.SelectTemplateAsync();
+                config.TemplateVersion = await _packageSelector.SelectTemplateVersionAsync(config.TemplateName);
                 break;
 
             case "Project name":
@@ -1042,9 +1042,9 @@ public class InteractiveModeWorkflow
                 config.Packages = string.Join(",", packageParts);
             }
 
-            // Update template fields
-            config.TemplateName = templateName;
-            config.TemplateVersion = templateVersion;
+            // Sync template fields from config to local variables
+            templateName = config.TemplateName;
+            templateVersion = config.TemplateVersion;
 
             // Display configuration table
             AnsiConsole.WriteLine();


### PR DESCRIPTION
Fixed issue where template name and template version were not being updated when editing configuration. The problem was that local string parameters were being updated instead of the config object properties.

Changes:
- Update config.TemplateName and config.TemplateVersion directly in ProcessConfigurationFieldAsync instead of local parameters
- Sync local variables from config object after processing fields
- This ensures template changes persist through the edit cycle

Fixes the compilation error that would occur with ref/out parameters in async methods by updating the object properties directly.