### PR TITLE
Potential fix for code scanning alert no. 3: URL redirection from remote source

### DIFF
--- a/src/PSW/Controllers/HomeController.cs
+++ b/src/PSW/Controllers/HomeController.cs
@@ -134,7 +134,15 @@ public class HomeController : Controller
     public IActionResult Index(PackagesViewModel model)
     {
         var queryString = _queryStringService.GenerateQueryStringFromModel(model);
-        return Redirect("/" + queryString);
+        var redirectUrl = "/" + queryString;
+        // Ensure that the redirect target is a relative URL, not absolute
+        var uri = new Uri(redirectUrl, UriKind.RelativeOrAbsolute);
+        if (uri.IsAbsoluteUri)
+        {
+            // Absolute URI detected - fallback to homepage
+            return Redirect("/");
+        }
+        return Redirect(redirectUrl);
     }
 
     [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]


### PR DESCRIPTION
Potential fix for [https://github.com/prjseal/Package-Script-Writer/security/code-scanning/3](https://github.com/prjseal/Package-Script-Writer/security/code-scanning/3)

To address this vulnerability, we need to validate or sanitize any user-controllable input before including it in a redirect. The goal is either (a) not to incorporate attacker-controlled values into the redirect at all, or (b) validate that the eventual redirect URL is only a relative URL within the application, and not an external absolute URL.

The most straightforward solution is to ensure that any generated query string is strictly relative and cannot be used to trick the redirect mechanism into going to an external page. In this case, we can validate all fields in `PackagesViewModel` for valid, expected values — particularly `OnelinerOutput`. Alternatively, we can explicitly check that the final URL is a relative URL and not an absolute external URL before redirecting. 

The fix should be implemented in the `HomeController.cs` file, updating the POST `Index` action. Before returning the redirect, parse the constructed URL and ensure it is a relative URL. If it isn't, redirect to a safe default location (e.g., home page).

This requires:
- Importing `System.Uri` (already available in .NET).
- Adding a check in the `Index(PackagesViewModel model)` method: validate that `"/" + queryString` is a relative URL (not absolute).
- Redirect only if the URL is safe, otherwise redirect to "/".

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
