### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,6 @@
 name: Build, publish and deploy project to UmbHost
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/prjseal/Package-Script-Writer/security/code-scanning/1](https://github.com/prjseal/Package-Script-Writer/security/code-scanning/1)

To fix this issue, add a `permissions` block to the workflow to explicitly set the minimal privileges needed for the GITHUB_TOKEN. According to the provided code, there are no steps that directly interact with repository contents beyond reading them (the workflow pulls code, builds locally, and deploys outside GitHub). Therefore, setting `contents: read` is the safest minimally privileged option. The `permissions` block should be added at the root of the workflow file (between `name:` and `on:`), ensuring all jobs use the least privilege unless expanded. No additional methods, imports, or definitions are needed for this YAML change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
