### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-packages.yml
+++ b/.github/workflows/update-packages.yml
@@ -18,6 +18,9 @@ on:
         required: false
         default: ''
 
+permissions:
+  contents: write
+  pull-requests: write
 env:
   SCHEDULED_INCLUDE_PRERELEASE: 'false'
 


### PR DESCRIPTION
Potential fix for [https://github.com/prjseal/Package-Script-Writer/security/code-scanning/2](https://github.com/prjseal/Package-Script-Writer/security/code-scanning/2)

To fix this problem, we should add a `permissions:` block to either the root of the workflow (to affect all jobs by default) or specifically to the relevant job (`update-packages`). The recommended approach is to add the block at the root level (immediately under the workflow name/on/env) for clarity and maintainability, unless jobs have differing permission requirements.

The least privilege starting point is usually `contents: read`, but reviewing the workflow indicates that the job will need to push commits and create pull requests. Therefore, adding:

```yaml
permissions:
  contents: write
  pull-requests: write
```
at the root of the YAML file, immediately after the `name:` or `on:` block (typically after `on:` but before `env:`), is the best solution. No changes to other imports, definitions, or methods are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
