### PR TITLE
Add condition to PreBuild target to respect RunPreBuildEvent property

### DIFF
--- a/src/PSW/PSW.csproj
+++ b/src/PSW/PSW.csproj
@@ -17,7 +17,7 @@
     <ProjectReference Include="..\PSW.Shared\PSW.Shared.csproj" />
   </ItemGroup>
 
-  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+  <Target Name="PreBuild" BeforeTargets="PreBuildEvent" Condition="'$(RunPreBuildEvent)' != 'false'">
     <Exec Command="dotnet format --severity warn --verbosity diagnostic" />
   </Target>
 </Project>


### PR DESCRIPTION
The PreBuild target was running dotnet format even when /p:RunPreBuildEvent=false
was passed to the build command. Adding Condition="'' != 'false'"
ensures that dotnet format is skipped when RunPreBuildEvent is set to false in CI builds.