### PR TITLE
Remove template show command feature

### DIFF
--- a/.github/template-commands-flow-diagrams.md
+++ b/.github/template-commands-flow-diagrams.md
@@ -192,49 +192,6 @@ flowchart TD
 
 ---
 
-## Template Show
-
-**Command**: `psw template show <name>`
-
-**Purpose**: Displays detailed metadata and configuration of a specific template.
-
-**File Reference**: `src/PackageCliTool/Workflows/TemplateWorkflow.cs:468-527`
-
-```mermaid
-flowchart TD
-    Start([Start: template show]) --> CheckName{Name<br/>provided?}
-    CheckName -->|No| PromptName[Prompt for template name]
-    CheckName -->|Yes| LoadTemplate[Load template from disk]
-    PromptName --> LoadTemplate
-
-    LoadTemplate --> BuildMetadata[Build metadata table:<br/>Description, Author, Version,<br/>Created, Modified, Tags]
-
-    BuildMetadata --> DisplayMetadata[Display metadata table<br/>Blue rounded border]
-    DisplayMetadata --> BuildConfig[Build configuration table:<br/>Template, Project, Solution,<br/>Packages, Starter Kit,<br/>Docker, Unattended]
-
-    BuildConfig --> ShowPackages{Packages<br/>exist?}
-    ShowPackages -->|Yes| AddPackages[Add package details:<br/>└─ PackageName @ Version]
-    ShowPackages -->|No| DisplayConfig[Display configuration table<br/>Green rounded border]
-    AddPackages --> DisplayConfig
-
-    DisplayConfig --> End([Exit])
-
-    style Start fill:#e1f5e1
-    style End fill:#ffe1e1
-    style LoadTemplate fill:#e3f2fd
-    style DisplayMetadata fill:#bbdefb
-    style DisplayConfig fill:#c8e6c9
-```
-
-**Key States**:
-1. `Initialization` → Check if name provided
-2. `LoadTemplate` → Read template from disk
-3. `DisplayMetadata` → Show template information
-4. `DisplayConfiguration` → Show settings
-5. `Exit`
-
----
-
 ## Template Delete
 
 **Command**: `psw template delete <name>`

--- a/src/PackageCliTool/Models/CommandLineOptions.cs
+++ b/src/PackageCliTool/Models/CommandLineOptions.cs
@@ -85,7 +85,7 @@ public class CommandLineOptions
     /// <summary>Gets or sets whether to enable verbose logging</summary>
     public bool VerboseMode { get; set; }
 
-    /// <summary>Gets or sets the template command (save, load, list, show, delete, export, import)</summary>
+    /// <summary>Gets or sets the template command (save, load, list, delete, export, import)</summary>
     public string? TemplateCommand { get; set; }
 
     /// <summary>Gets or sets the template name</summary>

--- a/src/PackageCliTool/TEMPLATES.md
+++ b/src/PackageCliTool/TEMPLATES.md
@@ -115,19 +115,6 @@ psw template list
 # └────────────────────┴─────────────────────────────┴──────────┴────────────────┘
 ```
 
-### `template show <name>`
-
-Displays detailed information about a template.
-
-**Example:**
-```bash
-psw template show my-blog
-
-# Shows:
-# - Metadata (name, description, author, version, tags, dates)
-# - Configuration (template, project, packages, options)
-```
-
 ### `template delete <name>`
 
 Deletes a template.

--- a/src/PackageCliTool/UI/ConsoleDisplay.cs
+++ b/src/PackageCliTool/UI/ConsoleDisplay.cs
@@ -82,7 +82,6 @@ public static class ConsoleDisplay
   [green]psw template save[/] <name>      Save current configuration as a template
   [green]psw template load[/] <name>      Load and execute a template
   [green]psw template list[/]             List all available templates
-  [green]psw template show[/] <name>      Show template details
   [green]psw template delete[/] <name>    Delete a template
   [green]psw template export[/] <name>    Export template to file
   [green]psw template import[/] <file>    Import template from file
@@ -191,7 +190,6 @@ public static class ConsoleDisplay
   [green]save[/] <name>          Save current configuration as a template
   [green]load[/] <name>          Load and execute a template
   [green]list[/]                 List all available templates
-  [green]show[/] <name>          Show template details
   [green]delete[/] <name>        Delete a template
   [green]export[/] <name>        Export template to file
   [green]import[/] <file>        Import template from file

--- a/src/PackageCliTool/Workflows/TemplateWorkflow.cs
+++ b/src/PackageCliTool/Workflows/TemplateWorkflow.cs
@@ -75,10 +75,6 @@ public class TemplateWorkflow
                 ListTemplates(options);
                 break;
 
-            case "show":
-                await ShowTemplateAsync(options);
-                break;
-
             case "delete":
                 DeleteTemplate(options);
                 break;
@@ -535,72 +531,7 @@ public class TemplateWorkflow
         AnsiConsole.Write(table);
         AnsiConsole.WriteLine();
         AnsiConsole.MarkupLine($"[dim]Total: {templates.Count} template(s)[/]");
-        AnsiConsole.MarkupLine("[dim]Use 'psw template show <name>' to view details[/]");
         AnsiConsole.MarkupLine("[dim]Use 'psw template load <name>' to use a template[/]");
-    }
-
-    /// <summary>
-    /// Shows details of a specific template
-    /// </summary>
-    private async Task ShowTemplateAsync(CommandLineOptions options)
-    {
-        var name = options.TemplateName;
-
-        if (string.IsNullOrWhiteSpace(name))
-        {
-            name = AnsiConsole.Ask<string>("Enter [green]template name[/]:");
-        }
-
-        _logger?.LogInformation("Showing template: {Name}", name);
-
-        var template = await _templateService.LoadTemplateAsync(name);
-
-        // Display metadata
-        var metadataTable = new Table()
-            .Border(TableBorder.Rounded)
-            .BorderColor(Color.Blue)
-            .Title($"[bold blue]Template: {template.Metadata.Name}[/]");
-
-        metadataTable.AddColumn("[bold]Property[/]");
-        metadataTable.AddColumn("[bold]Value[/]");
-
-        metadataTable.AddRow("Description", template.Metadata.Description);
-        metadataTable.AddRow("Author", template.Metadata.Author);
-        metadataTable.AddRow("Version", template.Metadata.Version);
-        metadataTable.AddRow("Created", template.Metadata.Created.ToString("yyyy-MM-dd HH:mm"));
-        metadataTable.AddRow("Modified", template.Metadata.Modified.ToString("yyyy-MM-dd HH:mm"));
-        metadataTable.AddRow("Tags", string.Join(", ", template.Metadata.Tags));
-
-        AnsiConsole.Write(metadataTable);
-        AnsiConsole.WriteLine();
-
-        // Display configuration
-        var configTable = new Table()
-            .Border(TableBorder.Rounded)
-            .BorderColor(Color.Green)
-            .Title("[bold green]Configuration[/]");
-
-        configTable.AddColumn("[bold]Setting[/]");
-        configTable.AddColumn("[bold]Value[/]");
-
-        configTable.AddRow("Template", $"{template.Configuration.Template.Name} @ {template.Configuration.Template.Version}");
-        configTable.AddRow("Project", template.Configuration.Project.Name);
-        configTable.AddRow("Solution", template.Configuration.Project.CreateSolution ? template.Configuration.Project.SolutionName ?? template.Configuration.Project.Name : "No");
-        configTable.AddRow("Packages", template.Configuration.Packages.Count > 0 ? $"{template.Configuration.Packages.Count} package(s)" : "None");
-
-        if (template.Configuration.Packages.Count > 0)
-        {
-            foreach (var pkg in template.Configuration.Packages)
-            {
-                configTable.AddRow($"  └─ {pkg.Name}", pkg.Version);
-            }
-        }
-
-        configTable.AddRow("Starter Kit", template.Configuration.StarterKit.Enabled ? template.Configuration.StarterKit.Package ?? "Yes" : "No");
-        configTable.AddRow("Docker", template.Configuration.Docker.Dockerfile || template.Configuration.Docker.DockerCompose ? "Yes" : "No");
-        configTable.AddRow("Unattended", template.Configuration.Unattended.Enabled ? $"Yes ({template.Configuration.Unattended.Database.Type})" : "No");
-
-        AnsiConsole.Write(configTable);
     }
 
     /// <summary>


### PR DESCRIPTION
- Removed ShowTemplateAsync method from TemplateWorkflow.cs
- Removed 'show' case from template command switch statement
- Updated CommandLineOptions.cs to remove 'show' from template command list
- Removed 'psw template show' from help text in ConsoleDisplay.cs
- Removed template show documentation section from TEMPLATES.md
- Removed template show flowchart from template-commands-flow-diagrams.md

The template show command is no longer available. Users can still use
'template list' to see available templates and 'template load' to use them.