### PR TITLE
Remove 'history stats' command feature

### DIFF
--- a/src/PackageCliTool.Tests/HistoryServiceTests.cs
+++ b/src/PackageCliTool.Tests/HistoryServiceTests.cs
@@ -313,53 +313,6 @@ public class HistoryServiceTests : IDisposable
     }
 
     [Fact]
-    public void GetStats_CalculatesCorrectly()
-    {
-        // Arrange
-        var historyService = new HistoryService(historyDirectory: _testHistoryDirectory);
-
-        // Add 3 entries: 2 executed (1 success, 1 failure), 1 from template
-        var entry1 = historyService.AddEntry(CreateTestScriptModel("Project1"), "Template1");
-        historyService.UpdateExecution(entry1.Id, "/tmp", exitCode: 0);
-
-        var entry2 = historyService.AddEntry(CreateTestScriptModel("Project2"));
-        historyService.UpdateExecution(entry2.Id, "/tmp", exitCode: 1);
-
-        var entry3 = historyService.AddEntry(CreateTestScriptModel("Project3"));
-
-        // Act
-        var stats = historyService.GetStats();
-
-        // Assert
-        stats.TotalEntries.Should().Be(3);
-        stats.ExecutedCount.Should().Be(2);
-        stats.SuccessfulCount.Should().Be(1);
-        stats.FailedCount.Should().Be(1);
-        stats.FromTemplateCount.Should().Be(1);
-        stats.MostRecentDate.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
-        stats.OldestDate.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
-    }
-
-    [Fact]
-    public void GetStats_WithEmptyHistory_ReturnsZeros()
-    {
-        // Arrange
-        var historyService = new HistoryService(historyDirectory: _testHistoryDirectory);
-
-        // Act
-        var stats = historyService.GetStats();
-
-        // Assert
-        stats.TotalEntries.Should().Be(0);
-        stats.ExecutedCount.Should().Be(0);
-        stats.SuccessfulCount.Should().Be(0);
-        stats.FailedCount.Should().Be(0);
-        stats.FromTemplateCount.Should().Be(0);
-        stats.MostRecentDate.Should().BeNull();
-        stats.OldestDate.Should().BeNull();
-    }
-
-    [Fact]
     public void HistoryService_PersistsToDisk()
     {
         // Arrange

--- a/src/PackageCliTool/HISTORY.md
+++ b/src/PackageCliTool/HISTORY.md
@@ -131,30 +131,6 @@ psw history clear
 # ✓ Cleared 42 history entries
 ```
 
-### `history stats`
-
-Shows statistics about your script generation history.
-
-**Example:**
-```bash
-psw history stats
-
-# Output:
-# ┌────────────────────────┬────────┐
-# │ Metric                 │ Value  │
-# ├────────────────────────┼────────┤
-# │ Total Entries          │ 42     │
-# │ Executed Scripts       │ 35     │
-# │ Successful Executions  │ 33     │
-# │ Failed Executions      │ 2      │
-# │ From Templates         │ 28     │
-# │ Most Recent            │ 2025...│
-# │ Oldest                 │ 2025...│
-# │ Max Entries            │ 50     │
-# └────────────────────────┴────────┘
-# Success Rate: 94.3%
-```
-
 ## History File Format
 
 ### Complete Example File
@@ -466,9 +442,6 @@ psw history rerun 1
 Find and analyze scripts that failed:
 
 ```bash
-# View stats to see failure count
-psw history stats
-
 # List history to find failed entries (marked in red)
 psw history list
 

--- a/src/PackageCliTool/Models/CommandLineOptions.cs
+++ b/src/PackageCliTool/Models/CommandLineOptions.cs
@@ -103,7 +103,7 @@ public class CommandLineOptions
     /// <summary>Gets or sets the community template name or 'list' to show all available templates</summary>
     public string? CommunityTemplate { get; set; }
 
-    /// <summary>Gets or sets the history command (list, show, rerun, delete, clear, stats)</summary>
+    /// <summary>Gets or sets the history command (list, show, rerun, delete, clear)</summary>
     public string? HistoryCommand { get; set; }
 
     /// <summary>Gets or sets the history entry ID or index</summary>
@@ -464,7 +464,7 @@ public class CommandLineOptions
                     if (!arg.StartsWith("-") && i == 0)
                     {
                         var templateCommands = new[] { "save", "load", "export", "import", "validate" };
-                        var historyCommands = new[] { "list", "delete", "rerun", "clear", "stats" };
+                        var historyCommands = new[] { "list", "delete", "rerun", "clear" };
 
                         // Check if it's a template command (some overlap, so check context)
                         if (templateCommands.Contains(arg.ToLower()))

--- a/src/PackageCliTool/Services/HistoryService.cs
+++ b/src/PackageCliTool/Services/HistoryService.cs
@@ -220,48 +220,4 @@ public class HistoryService
     {
         return _history.MaxEntries;
     }
-
-    /// <summary>
-    /// Gets statistics about the history
-    /// </summary>
-    public HistoryStats GetStats()
-    {
-        return new HistoryStats
-        {
-            TotalEntries = _history.Entries.Count,
-            ExecutedCount = _history.Entries.Count(e => e.WasExecuted),
-            SuccessfulCount = _history.Entries.Count(e => e.WasExecuted && e.ExitCode == 0),
-            FailedCount = _history.Entries.Count(e => e.WasExecuted && e.ExitCode != 0),
-            FromTemplateCount = _history.Entries.Count(e => !string.IsNullOrWhiteSpace(e.TemplateName)),
-            MostRecentDate = _history.Entries.FirstOrDefault()?.Timestamp,
-            OldestDate = _history.Entries.LastOrDefault()?.Timestamp
-        };
-    }
-}
-
-/// <summary>
-/// Statistics about the history
-/// </summary>
-public class HistoryStats
-{
-    /// <summary>Gets or sets the total number of history entries</summary>
-    public int TotalEntries { get; set; }
-
-    /// <summary>Gets or sets the number of executed scripts</summary>
-    public int ExecutedCount { get; set; }
-
-    /// <summary>Gets or sets the number of successful script executions</summary>
-    public int SuccessfulCount { get; set; }
-
-    /// <summary>Gets or sets the number of failed script executions</summary>
-    public int FailedCount { get; set; }
-
-    /// <summary>Gets or sets the number of entries created from templates</summary>
-    public int FromTemplateCount { get; set; }
-
-    /// <summary>Gets or sets the timestamp of the most recent entry</summary>
-    public DateTime? MostRecentDate { get; set; }
-
-    /// <summary>Gets or sets the timestamp of the oldest entry</summary>
-    public DateTime? OldestDate { get; set; }
 }

--- a/src/PackageCliTool/UI/ConsoleDisplay.cs
+++ b/src/PackageCliTool/UI/ConsoleDisplay.cs
@@ -97,7 +97,6 @@ public static class ConsoleDisplay
   [green]psw history rerun[/] <#>         Regenerate and re-run a script from history
   [green]psw history delete[/] <#>        Delete a history entry
   [green]psw history clear[/]             Clear all history
-  [green]psw history stats[/]             Show history statistics
 
 [bold yellow]HISTORY OPTIONS:[/]
   [green]    --history-limit[/] <count>  Number of entries to show (default: 10)
@@ -152,9 +151,6 @@ public static class ConsoleDisplay
 
   Re-run a previous script:
     [cyan]psw history rerun 1[/]
-
-  View statistics:
-    [cyan]psw history stats[/]
 
   Clear all history:
     [cyan]psw history clear[/]
@@ -240,7 +236,6 @@ public static class ConsoleDisplay
   [green]rerun[/] <#>             Regenerate and re-run a script from history
   [green]delete[/] <#>            Delete a history entry
   [green]clear[/]                 Clear all history
-  [green]stats[/]                 Show history statistics
 
 [bold yellow]HISTORY OPTIONS:[/]
   [green]    --history-limit[/] <count>  Number of entries to show (default: 10)
@@ -251,9 +246,6 @@ public static class ConsoleDisplay
 
   Re-run a previous script:
     [cyan]psw history rerun 1[/]
-
-  View statistics:
-    [cyan]psw history stats[/]
 
   Clear all history:
     [cyan]psw history clear[/]")

--- a/src/PackageCliTool/Workflows/HistoryWorkflow.cs
+++ b/src/PackageCliTool/Workflows/HistoryWorkflow.cs
@@ -73,10 +73,6 @@ public class HistoryWorkflow
                 ClearHistory();
                 break;
 
-            case "stats":
-                ShowStats();
-                break;
-
             default:
                 AnsiConsole.MarkupLine($"[red]Error: Unknown history command '{command}'[/]\n");
                 ConsoleDisplay.DisplayHistoryHelp();
@@ -325,48 +321,6 @@ public class HistoryWorkflow
 
         _historyService.ClearAll();
         AnsiConsole.MarkupLine($"[green]✓ Cleared {count} history entries[/]");
-    }
-
-    /// <summary>
-    /// Shows history statistics
-    /// </summary>
-    private void ShowStats()
-    {
-        _logger?.LogInformation("Showing history statistics");
-
-        var stats = _historyService.GetStats();
-
-        if (stats.TotalEntries == 0)
-        {
-            AnsiConsole.MarkupLine("[yellow]No history entries found.[/]");
-            return;
-        }
-
-        var table = new Table()
-            .Border(TableBorder.Rounded)
-            .BorderColor(Color.Aqua)
-            .Title("[bold cyan]History Statistics[/]");
-
-        table.AddColumn("[bold]Metric[/]");
-        table.AddColumn("[bold]Value[/]");
-
-        table.AddRow("Total Entries", stats.TotalEntries.ToString());
-        table.AddRow("Executed Scripts", stats.ExecutedCount.ToString());
-        table.AddRow("Successful Executions", $"[green]{stats.SuccessfulCount}[/]");
-        table.AddRow("Failed Executions", stats.FailedCount > 0 ? $"[red]{stats.FailedCount}[/]" : "0");
-        table.AddRow("From Templates", stats.FromTemplateCount.ToString());
-        table.AddRow("Most Recent", stats.MostRecentDate?.ToLocalTime().ToString("yyyy-MM-dd HH:mm") ?? "N/A");
-        table.AddRow("Oldest", stats.OldestDate?.ToLocalTime().ToString("yyyy-MM-dd HH:mm") ?? "N/A");
-        table.AddRow("Max Entries", _historyService.GetMaxEntries().ToString());
-
-        AnsiConsole.Write(table);
-
-        if (stats.ExecutedCount > 0)
-        {
-            var successRate = (stats.SuccessfulCount / (double)stats.ExecutedCount) * 100;
-            AnsiConsole.WriteLine();
-            AnsiConsole.MarkupLine($"[dim]Success Rate: {successRate:F1}%[/]");
-        }
     }
 
     /// <summary>


### PR DESCRIPTION
Removed the 'history stats' command and all associated code, tests, and documentation:
- Removed ShowStats() method from HistoryWorkflow.cs
- Removed GetStats() method and HistoryStats class from HistoryService.cs
- Removed stats command case from history command switch in HistoryWorkflow.cs
- Removed stats-related tests from HistoryServiceTests.cs
- Updated help text in ConsoleDisplay.cs to remove stats command
- Updated CommandLineOptions.cs to remove stats from valid history commands
- Removed stats command documentation from HISTORY.md