### PR TITLE
Remove unused code from PackageCliTool

### DIFF
--- a/src/PackageCliTool/Logging/ErrorHandler.cs
+++ b/src/PackageCliTool/Logging/ErrorHandler.cs
@@ -147,22 +147,4 @@ public static class ErrorHandler
         logger?.LogWarning(message);
         AnsiConsole.MarkupLine($"[yellow]⚠ {message.EscapeMarkup()}[/]");
     }
-
-    /// <summary>
-    /// Displays an informational message
-    /// </summary>
-    public static void Info(string message, ILogger? logger = null)
-    {
-        logger?.LogInformation(message);
-        AnsiConsole.MarkupLine($"[blue]ℹ {message.EscapeMarkup()}[/]");
-    }
-
-    /// <summary>
-    /// Displays a success message
-    /// </summary>
-    public static void Success(string message, ILogger? logger = null)
-    {
-        logger?.LogInformation(message);
-        AnsiConsole.MarkupLine($"[green]✓ {message.EscapeMarkup()}[/]");
-    }
 }

--- a/src/PackageCliTool/Logging/LoggerSetup.cs
+++ b/src/PackageCliTool/Logging/LoggerSetup.cs
@@ -52,19 +52,6 @@ public static class LoggerSetup
     }
 
     /// <summary>
-    /// Creates a logger for the specified type
-    /// </summary>
-    public static ILogger<T> CreateLogger<T>()
-    {
-        if (_loggerFactory == null)
-        {
-            Initialize();
-        }
-
-        return _loggerFactory!.CreateLogger<T>();
-    }
-
-    /// <summary>
     /// Creates a logger with the specified category name
     /// </summary>
     public static Microsoft.Extensions.Logging.ILogger CreateLogger(string categoryName)

--- a/src/PackageCliTool/Validation/CommandValidator.cs
+++ b/src/PackageCliTool/Validation/CommandValidator.cs
@@ -178,28 +178,4 @@ public class CommandValidator
 
         return patterns;
     }
-
-    /// <summary>
-    /// Gets a list of example allowed commands for documentation purposes
-    /// </summary>
-    public static List<string> GetAllowedCommandExamples()
-    {
-        return new List<string>
-        {
-            "dotnet new install Umbraco.Templates::14.3.0 --force",
-            "dotnet new -i Umbraco.Templates::10.0.0",
-            "dotnet new sln --name \"MySolution\"",
-            "dotnet new umbraco --force -n \"MyProject\"",
-            "dotnet new umbraco-compose -P \"MyProject\"",
-            "dotnet sln add \"MyProject\"",
-            "dotnet add package PackageName --version 1.0.0",
-            "dotnet add \"MyProject\" package PackageName",
-            "dotnet run --project \"MyProject\"",
-            "dotnet build",
-            "dotnet restore",
-            "@echo off (Windows only)",
-            "$env:ASPNETCORE_ENVIRONMENT=Development (Windows only)",
-            "dotnet new install Umbraco.Templates::14.3.0 --force && dotnet new umbraco -n \"MyProject\" && dotnet run (one-liner with && chaining)"
-        };
-    }
 }

--- a/src/PackageCliTool/Workflows/CliModeWorkflow.cs
+++ b/src/PackageCliTool/Workflows/CliModeWorkflow.cs
@@ -148,7 +148,6 @@ public class CliModeWorkflow
             .StartAsync("Generating default installation script...", async ctx =>
             {
                 return _scriptGeneratorService.GenerateScript(model.ToViewModel());
-                //return await _apiClient.GenerateScriptAsync(model);
             });
 
         _logger?.LogInformation("Default script generated successfully");
@@ -253,7 +252,6 @@ public class CliModeWorkflow
             .StartAsync("Generating installation script...", async ctx =>
             {
                 return _scriptGeneratorService.GenerateScript(model.ToViewModel());
-                //return await _apiClient.GenerateScriptAsync(model);
             });
 
         _logger?.LogInformation("Script generated successfully");

--- a/src/PackageCliTool/Workflows/InteractiveModeWorkflow.cs
+++ b/src/PackageCliTool/Workflows/InteractiveModeWorkflow.cs
@@ -208,7 +208,6 @@ public class InteractiveModeWorkflow
             .StartAsync("Generating installation script...", async ctx =>
             {
                 return _scriptGeneratorService.GenerateScript(model.ToViewModel());
-                //return await _apiClient.GenerateScriptAsync(model);
             });
 
         _logger?.LogInformation("Script generated successfully");
@@ -1417,26 +1416,6 @@ public class InteractiveModeWorkflow
 
         AnsiConsole.WriteLine();
         ConsoleDisplay.DisplayUmbracoVersions(_pswConfig);
-        AnsiConsole.WriteLine();
-    }
-
-    /// <summary>
-    /// Clears the package cache
-    /// </summary>
-    private async Task ClearCacheAsync()
-    {
-        _logger?.LogInformation("Clearing cache");
-
-        // Clear the cache service
-        var cacheService = new CacheService(ttlHours: 1, enabled: true, logger: _logger);
-        cacheService.Clear();
-
-        AnsiConsole.MarkupLine("[green]✓ Cache cleared successfully[/]");
-
-        // Repopulate packages
-        AnsiConsole.MarkupLine("[dim]Reloading packages...[/]");
-        await _packageSelector.PopulateAllPackagesAsync(forceUpdate: true);
-
         AnsiConsole.WriteLine();
     }
 


### PR DESCRIPTION
Removed the following unused code:
- ErrorHandler.Info() and ErrorHandler.Success() methods (never called)
- CommandValidator.GetAllowedCommandExamples() method (never called)
- LoggerSetup.CreateLogger<T>() generic method (never used)
- InteractiveModeWorkflow.ClearCacheAsync() method (never called)
- Commented-out API client calls in workflow files (replaced by direct script generator service calls)

This cleanup removes 78 lines of dead code, improving code maintainability.