### PR TITLE
Fix duplicate content items error for community-templates

### DIFF
--- a/src/PSW/PSW.csproj
+++ b/src/PSW/PSW.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="community-templates\**\*">
+    <Content Update="community-templates\**\*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>


### PR DESCRIPTION
Changed Content Include to Update to avoid duplicates with SDK's automatic content inclusion in .NET 10.0