### PR TITLE
Fix: Add missing EnableContentDeliveryApi field to JavaScript API request

### DIFF
--- a/src/PSW/wwwroot/js/site.js
+++ b/src/PSW/wwwroot/js/site.js
@@ -651,6 +651,7 @@
             "IncludeStarterKit": psw.controls.includeStarterKit.checked,
             "IncludeDockerfile": psw.controls.includeDockerfile.checked,
             "IncludeDockerCompose": psw.controls.includeDockerCompose.checked,
+            "EnableContentDeliveryApi": psw.controls.enableContentDeliveryApi.checked,
             "StarterKitPackage": psw.controls.starterKitPackage.value,
             "OnelinerOutput": psw.controls.onelinerOutput.checked,
             "RemoveComments": psw.controls.removeComments.checked


### PR DESCRIPTION
The website UI was not sending the EnableContentDeliveryApi field in the
AJAX request, causing the -da flag to not appear in the generated script
even when the checkbox was checked.

This adds the missing field to the data object in the updateOutput function.