### PR TITLE
Fix: Remove Produces attribute to bypass content negotiation for YAML…

### DIFF
--- a/src/PSW/Controllers/CommunityTemplatesApiController.cs
+++ b/src/PSW/Controllers/CommunityTemplatesApiController.cs
@@ -87,11 +87,6 @@ public class CommunityTemplatesApiController : ControllerBase
     /// <response code="404">If the template file is not found</response>
     /// <response code="500">If there's an error reading the template file</response>
     [HttpGet("template/{fileName}")]
-    [Produces("text/plain")]
-    [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetTemplate(string fileName)
     {
         // Sanitize user input immediately for logging - only allow letters and spaces


### PR DESCRIPTION
… templates

The [Produces] attribute was causing ASP.NET Core to enforce content negotiation, resulting in 406 errors even with ReturnHttpNotAcceptable = false. By removing the attribute entirely, the endpoint now returns text/plain content directly without any content type negotiation, resolving the 406 issue.

The endpoint still returns the YAML template as text/plain (line 140), which the CLI already handles correctly.