### PR TITLE
Fix SQL Server connection string prompt and bump CLI to 1.2.1

### DIFF
--- a/src/PackageCliTool/CHANGELOG.md
+++ b/src/PackageCliTool/CHANGELOG.md
@@ -7,8 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.1] - 2026-05-01
+
 ### Added
 - **Umbraco AI Kitchen Sink Community Template** - New community template by Matt Brailsford covering the full Umbraco AI package suite including all providers (OpenAI, Anthropic, Google, Amazon, Microsoft Foundry), AI Prompt, and AI Agents
+
+### Fixed
+- **Empty Connection String Crash** - When selecting SQL Server or SQL Azure as the database type in interactive mode, leaving the connection string blank no longer crashes the CLI. The prompt now accepts an empty value (so the user can exit it) and only validates format when a value is supplied
 
 ## [1.2.0] - 2026-03-04
 
@@ -130,7 +135,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Secure password input
   - No script storage (regenerated from config)
 
-[Unreleased]: https://github.com/prjseal/Package-Script-Writer/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/prjseal/Package-Script-Writer/compare/v1.2.1...HEAD
+[1.2.1]: https://github.com/prjseal/Package-Script-Writer/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/prjseal/Package-Script-Writer/compare/v1.1.2...v1.2.0
 [1.1.2]: https://github.com/prjseal/Package-Script-Writer/compare/v1.1.1...v1.1.2
 [1.1.1]: https://github.com/prjseal/Package-Script-Writer/compare/v1.1.0...v1.1.1

--- a/src/PackageCliTool/PackageCliTool.csproj
+++ b/src/PackageCliTool/PackageCliTool.csproj
@@ -12,7 +12,7 @@
 
     <!-- Package Metadata -->
     <PackageId>PackageScriptWriter.Cli</PackageId>
-    <Version>1.2.0</Version>
+    <Version>1.2.1</Version>
     <Authors>Paul Seal</Authors>
     <Company>CodeShare</Company>
     <Description>Interactive CLI tool for generating Umbraco CMS installation scripts. Features a beautiful terminal UI with Spectre.Console, supports 500+ Marketplace packages, includes template system for reusable configurations, and offers both interactive and automation modes for CI/CD pipelines.</Description>
@@ -60,6 +60,9 @@
     <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
     <PackageReference Include="YamlDotNet" Version="16.2.1" />
     <PackageReference Include="TextCopy" Version="6.2.1" />
+
+    <!-- Umbraco reference for Marketplace eligibility -->
+    <PackageReference Include="Umbraco.JsonSchema.Extensions" Version="0.4.0" />
 
     <!-- Source Link Support -->
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />

--- a/src/PackageCliTool/README.md
+++ b/src/PackageCliTool/README.md
@@ -48,7 +48,7 @@ dotnet tool update --global PackageScriptWriter.Cli
 dotnet tool update --global PackageScriptWriter.Cli --prerelease
 
 # Update to a specific version
-dotnet tool update --global PackageScriptWriter.Cli --version 1.2.0
+dotnet tool update --global PackageScriptWriter.Cli --version 1.2.1
 ```
 
 ### From Source

--- a/src/PackageCliTool/UI/ConsoleDisplay.cs
+++ b/src/PackageCliTool/UI/ConsoleDisplay.cs
@@ -225,7 +225,7 @@ public static class ConsoleDisplay
     [cyan]dotnet tool update --global PackageScriptWriter.Cli --prerelease[/]
 
   Update to a specific version:
-    [cyan]dotnet tool update --global PackageScriptWriter.Cli --version 1.2.0[/]
+    [cyan]dotnet tool update --global PackageScriptWriter.Cli --version 1.2.1[/]
 
   Check current version:
     [cyan]psw --version[/]")

--- a/src/PackageCliTool/UI/InteractivePrompts.cs
+++ b/src/PackageCliTool/UI/InteractivePrompts.cs
@@ -179,7 +179,7 @@ public static class InteractivePrompts
 
             if (model.DatabaseType == "SQLServer" || model.DatabaseType == "SQLAzure")
             {
-                model.ConnectionString = AnsiConsole.Ask<string>("Enter [green]connection string[/]:", existingModel?.ConnectionString ?? string.Empty);
+                model.ConnectionString = PromptForConnectionString(existingModel?.ConnectionString);
             }
 
             model.UserFriendlyName = AnsiConsole.Ask<string>("Enter [green]admin user friendly name[/]:", existingModel?.UserFriendlyName ?? "Administrator");
@@ -244,5 +244,33 @@ public static class InteractivePrompts
     public static bool ConfirmScriptGeneration()
     {
         return AnsiConsole.Confirm("\nGenerate script with these settings?", true);
+    }
+
+    /// <summary>
+    /// Prompts the user for a SQL Server / SQL Azure connection string and re-prompts on empty/invalid input.
+    /// </summary>
+    public static string PromptForConnectionString(string? existingValue)
+    {
+        var prompt = new TextPrompt<string>("Enter [green]connection string[/] [dim](leave blank to skip)[/]:")
+            .AllowEmpty()
+            .Validate(value =>
+            {
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    return ValidationResult.Success();
+                }
+                if (!value.Contains(';') && !value.Contains('='))
+                {
+                    return ValidationResult.Error("Invalid connection string format (e.g. 'Server=localhost;Database=MyDb;...')");
+                }
+                return ValidationResult.Success();
+            });
+
+        if (!string.IsNullOrWhiteSpace(existingValue))
+        {
+            prompt.DefaultValue(existingValue);
+        }
+
+        return AnsiConsole.Prompt(prompt) ?? string.Empty;
     }
 }

--- a/src/PackageCliTool/Workflows/InteractiveModeWorkflow.cs
+++ b/src/PackageCliTool/Workflows/InteractiveModeWorkflow.cs
@@ -1092,16 +1092,14 @@ public class InteractiveModeWorkflow
                 if (config.DatabaseType == "SQLServer" || config.DatabaseType == "SQLAzure")
                 {
                     AnsiConsole.MarkupLine("[yellow]Connection string is required for SQLServer/SQLAzure[/]");
-                    config.ConnectionString = AnsiConsole.Ask<string>("Enter [green]connection string[/]:", config.ConnectionString ?? string.Empty);
-                    InputValidator.ValidateConnectionString(config.ConnectionString, config.DatabaseType);
+                    config.ConnectionString = InteractivePrompts.PromptForConnectionString(config.ConnectionString);
                 }
                 break;
 
             case "Connection string":
                 if (config.DatabaseType == "SQLServer" || config.DatabaseType == "SQLAzure")
                 {
-                    config.ConnectionString = AnsiConsole.Ask<string>("Enter [green]connection string[/]:", config.ConnectionString ?? string.Empty);
-                    InputValidator.ValidateConnectionString(config.ConnectionString, config.DatabaseType);
+                    config.ConnectionString = InteractivePrompts.PromptForConnectionString(config.ConnectionString);
                 }
                 else
                 {


### PR DESCRIPTION
- Connection string prompt no longer crashes when left blank; empty input is now accepted as a way to skip/exit, and format is only validated when a value is supplied
- Add Umbraco.JsonSchema.Extensions package reference for Umbraco Marketplace eligibility (zero transitive deps)
- Bump CLI version to 1.2.1 and update changelog